### PR TITLE
Multi impact

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -11,7 +11,7 @@ from climada.util.api_client import Client
 from indirect_impacts.compute import supply_chain_climada
 from indirect_impacts.visualization import create_supply_chain_vis
 from utils.s3client import download_from_s3_bucket, upload_to_s3_bucket
-from direct import nccs_direct_impacts_list_simple
+from direct import nccs_direct_impacts_list_simple, get_sector_exposure
 from calc_yearset import nccs_yearsets_simple
 
 country_list = ['Saint Kitts and Nevis', 'Jamaica']
@@ -55,7 +55,11 @@ def calc_supply_chain_impacts(
 
     # Generate supply chain impacts from the yearsets
     analysis_df['supchain'] = [
-        supply_chain_climada(row['exp'], row['yearset'], impacted_sector=row['sector'], io_approach='ghosh')
+        supply_chain_climada(
+            get_sector_exposure(sector=row['sector'], country=row['country']),
+            row['yearset'],
+            impacted_sector=row['sector'],
+            io_approach='ghosh')
         for _, row in analysis_df.iterrows()
     ]
 

--- a/analysis.py
+++ b/analysis.py
@@ -1,3 +1,10 @@
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+from climada.util.api_client import Client
+from climada_petals.engine import SupplyChain
+from climada.entity import ImpfTropCyclone, ImpactFuncSet, Exposures
 from climada.engine.impact_calc import ImpactCalc
 from climada.entity import ImpactFuncSet, ImpfTropCyclone
 from climada.util.api_client import Client
@@ -5,44 +12,39 @@ from climada.util.api_client import Client
 from indirect_impacts.compute import supply_chain_climada
 from indirect_impacts.visualization import create_supply_chain_vis
 from utils.s3client import download_from_s3_bucket, upload_to_s3_bucket
+from direct import direct_impact_eventset_list_simple
 
+country_list = ['Saint Kitts and Nevis', 'Jamaica']
+hazard_list = ['tropical_cyclone', 'river_flood']
+sector_list = ['litpop_1', 'litpop_1.5']
+scenario = 'rcp60'
+ref_year = 2080
+n_sim_years = 100
 
-def main():
+def calc_supply_chain_impacts(
+        country_list,
+        hazard_list,
+        sector_list,
+        scenario,
+        ref_year,
+        n_sim_years,
+        save_by_country=False,
+        save_by_hazard=False,
+        save_by_sector=False,
+        seed=1312
+):
 
-    # @chris to fetch some data: Make sure to set the environment variables first
-    #  (see .sample_dotenv and utils.s3client.py) I have no access rights to do this
-    #  (don't see any access tokens on my page, only a warning "no access")
-    # with open("test.txt", "w") as f:
-    #     f.write("test")
-    #
-    # upload_to_s3_bucket(input_filepath="test.txt", s3_filename="my-data-asset")
-    # download_from_s3_bucket(s3_filename="my-data-asset", output_path="test2.txt")
-    #
-    # os.remove("test.txt")
-    # os.remove("test2.txt")
+    ### --------------------------------- ###
+    ### CALCULATE DIRECT ECONOMIC IMPACTS ###
+    ### --------------------------------- ###
 
-    client = Client()
+    direct_impacts = direct_impact_eventset_list_simple(hazard_list, sector_list, country_list, scenario, ref_year)
 
-    ### ------------------------------------ ###
-    ### 1. CALCULATE DIRECT ECONOMIC IMPACTS ###
-    ### ------------------------------------ ###
+    ### ------------------- ###
+    ### SAMPLE IMPACT YEARS ###
+    ### ------------------- ###
 
-    exp_usa = client.get_litpop('USA')
-
-    tc_usa = client.get_hazard(
-        'tropical_cyclone',
-        properties={'country_iso3alpha': 'USA', 'climate_scenario': 'historical'}
-    )
-
-    # Define direct_impact function
-    impf_tc = ImpfTropCyclone.from_emanuel_usa()
-    impf_set = ImpactFuncSet()
-    impf_set.append(impf_tc)
-    impf_set.check()
-
-    # Calculate direct impacts to the USA due to TC
-    imp_calc = ImpactCalc(exp_usa, impf_set, tc_usa)
-    direct_impact_usa = imp_calc.impact()
+    # TODO
 
     ### ----------------------------------- ###
     ### CALCULATE INDIRECT ECONOMIC IMPACTS ###
@@ -55,4 +57,10 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    calc_supply_chain_impacts(
+        country_list,
+        hazard_list,
+        sector_list,
+        scenario,
+        ref_year
+    )

--- a/calc_yearset.py
+++ b/calc_yearset.py
@@ -13,8 +13,6 @@ def nccs_yearsets_simple(impact_list, n_sim_years, seed=1312):
 
 
 def yimp_from_imp_simple(imp,  n_sim_years, seed=1312):
-    # We estimate lamda (the mean events per year in our poisson distribution) from the event set total frequency
-    # TODO this is incorrect: the lambda should be divided by the total years in the event set. I think?
     lam = np.sum(imp.frequency)
     yimp, _ = yearsets.impact_yearset(
         imp,

--- a/calc_yearset.py
+++ b/calc_yearset.py
@@ -1,0 +1,27 @@
+import numpy as np
+import random
+from climada.util import yearsets
+
+def nccs_yearsets_simple(impact_list, n_sim_years, seed=1312):
+    '''
+    Generate yearsets from a list of impact objects.
+    TODO: Make this more complex so that the year sampling is consistent across hazards
+    i.e. when Cyclone X is selected in year Y for one yearset, it is selected in all cyclone yearsets
+    '''
+    random.seed(seed)
+    return [yimp_from_imp_simple(imp, n_sim_years, seed=random.randint(1,999999999)) for imp in impact_list]
+
+
+def yimp_from_imp_simple(imp,  n_sim_years, seed=1312):
+    # We estimate lamda (the mean events per year in our poisson distribution) from the event set total frequency
+    # TODO this is incorrect: the lambda should be divided by the total years in the event set. I think?
+    lam = np.sum(imp.frequency)
+    yimp, _ = yearsets.impact_yearset(
+        imp,
+        lam=lam,
+        sampled_years=list(range(1,n_sim_years+1)),
+        correction_fac=False,
+        seed=seed
+        )
+    return yimp
+        

--- a/direct.py
+++ b/direct.py
@@ -21,7 +21,6 @@ def nccs_direct_impacts_list_simple(hazard_list, sector_list, country_list, scen
         dict(
             haz_type=haz_type,
             sector=sector,
-            exp=get_sector_exposure(sector, country),
             country=country,
             scenario=scenario,
             ref_year=ref_year,

--- a/direct.py
+++ b/direct.py
@@ -1,0 +1,68 @@
+import pycountry
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+from climada.util.api_client import Client
+from climada_petals.engine import SupplyChain
+from climada.entity import ImpfTropCyclone, ImpactFuncSet, Exposures
+from climada.engine.impact_calc import ImpactCalc
+
+HAZ_TYPE_LOOKUP = {
+    'tropical_cyclone': 'TC',
+    'river_flood': 'RF'
+}
+
+
+# Method to loop through configuration lists of and run an impact calculation for each combination on the list
+# Simple, but can be sped up.
+def direct_impact_eventset_list_simple(hazard_list, sector_list, country_list, scenario, ref_year):
+    return pd.DataFrame(
+        dict(
+            haz_type=haz_type,
+            sector=sector,
+            country=country,
+            scenario=scenario,
+            ref_year=ref_year,
+            impact=direct_impact_eventset_simple(haz_type, sector, country, scenario, ref_year)
+        )
+        for haz_type in hazard_list for sector in sector_list for country in country_list
+    )
+
+def direct_impact_eventset_simple(haz_type, sector, country, scenario, ref_year):
+    country_iso3alpha = pycountry.countries.get(name=country).alpha_3
+    haz = get_hazard(haz_type, country_iso3alpha, scenario, ref_year)
+    exp = get_sector_exposure(sector, country)
+    impf_set = get_sector_impf_set(haz_type, sector, country)
+    return ImpactCalc(exp, impf_set, haz).impact(save_mat=True)
+
+
+def get_sector_exposure(sector, country):
+    if sector[0:6] == 'litpop':
+        scaling = float(sector[7:])
+        client = Client()
+        exp = client.get_litpop(country)
+        exp.gdf['value'] = exp.gdf['value'] * scaling / 100
+        return exp
+    else:
+        raise ValueError('So far we only work with LitPop exposures')
+
+
+def get_sector_impf_set(hazard, sector, country):
+    return ImpactFuncSet([get_sector_impf(hazard, sector, country)])
+
+
+def get_sector_impf(hazard, sector, country):
+    impf = ImpfTropCyclone.from_emanuel_usa()
+    impf.haz_type = HAZ_TYPE_LOOKUP[hazard]
+    return impf
+
+
+def get_hazard(haz_type, country_iso3alpha, scenario, ref_year):
+    client = Client()
+    if haz_type == 'tropical_cyclone':
+        return client.get_hazard(haz_type, properties={'country_iso3alpha': country_iso3alpha, 'climate_scenario': scenario, 'ref_year': str(ref_year)})
+    elif haz_type == 'river_flood':
+        year_range_midpoint = round(ref_year/20) * 20
+        year_range = str(year_range_midpoint - 10) + '_' + str(year_range_midpoint + 10)
+        return client.get_hazard(haz_type, properties={'country_iso3alpha': country_iso3alpha, 'climate_scenario': scenario, 'year_range': year_range})


### PR DESCRIPTION
This PR updates the analysis.py method to take user-supplied lists of countries, hazard types and sectors as inputs.

It then generates a data frame with all combinations of countries, hazards and sectors and calculates a CLIMADA impact object for each one.

Then, for each impact object it generates a yearset, randomly sampling the years based on the event frequencies.

A couple points:
- The yearset Impact objects aren't yet compatible with the supply chain module. The supply chain needs access to the Impact object's impact matrix, and yearsets are created without an impact matrix. @aleeciu is this something you could change? If not I can try to do it this week.
- `direct.py` contains methods to get hazards, exposures and impact function based on the input list criteria. We can modify these as we get more data, but right now they just grab the relevant hazard, litpop exposure data and the Emanuel TC impact function regardless of the inputs.
- The yearset sampling is naïve, in that every impact object is sampled independently of the others. I'll rewrite this soon so that if Cyclone W hits a one sector in one country  it also hits the other sectors and countries in the same year.