### PR TITLE
Config

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -37,7 +37,8 @@ Tropical Cyclones:
     "synthetic", could also use "observed"
 
 River Flood: 
-    'year_range': ['2010_2030','2030_2050','2050_2070','2070_2090','historical'], # officialy in API 'historical' would be '1980_2000'
+    'year_range': ['2010_2030','2030_2050','2050_2070','2070_2090','historical'], # officialy in API 'historical' 
+    would be '1980_2000'
     'climate_scenario': ['rcp26', 'rcp85', 'None', 'rcp60'] # officialy in API, 'None' would be 'historical'
 
     combination that are allowed:
@@ -73,56 +74,82 @@ Wildfire:
 Agriculture: Relative Cropyield
     hazard: 'relative_crop_yield'
     sector: 'agriculture'
-    scenario = 'climate_scenario': ['historical', 'rcp60'] & ref_year = 'year_range': ['1971_2001', '1980_2012', '2006_2099', '1976_2005']    
+    scenario = 'climate_scenario': ['historical', 'rcp60'] & ref_year = 'year_range': ['1971_2001', '1980_2012', 
+    '2006_2099', '1976_2005']    
     hazard_list = ['relative_crop_yield']  # ['tropical_cyclone', 'river_flood', 'storm_europe', 'relative_crop_yield']
 """
 
+# Check for country names with this website:
+# https://github.com/flyingcircusio/pycountry/blob/main/src/pycountry/databases/iso3166-1.json
+#
+# country_list = ['United States']
+# ALL_COUNTRIES = ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
+#                  'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados',
+#                  'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia, Plurinational State of',
+#                  'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei Darussalam', 'Bulgaria', 'Burkina Faso',
+#                  'Burundi', 'Cabo Verde', 'Cambodia', 'Cameroon',
+#                  'Canada', 'Central African Republic', 'Chad', 'Chile', 'China', 'Colombia', 'Comoros', 'Congo',
+#                  'Congo, The Democratic Republic of the', 'Costa Rica', 'Croatia', "Côte d'Ivoire",
+#                  'Cuba', 'Cyprus', 'Czechia', 'Denmark', 'Djibouti', 'Dominica', 'Dominican Republic',
+#                  'Timor-Leste', 'Ecuador', 'Egypt', 'El Salvador', 'Equatorial Guinea', 'Eritrea',
+#                  'Estonia', 'Eswatini', 'Ethiopia', 'Fiji', 'Finland', 'France', 'Gabon', 'Gambia', 'Georgia',
+#                  'Germany', 'Ghana', 'Greece', 'Grenada', 'Guatemala', 'Guinea', 'Guinea-Bissau', 'Guyana', 'Haiti',
+#                  'Honduras', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran, Islamic Republic of', 'Iraq',
+#                  'Ireland', 'Israel', 'Italy', 'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati',
+#                  "Korea, Democratic People's Republic of",
+#                  'Korea, Republic of', 'Kuwait', 'Kyrgyzstan', "Lao People's Democratic Republic", 'Latvia',
+#                  'Lebanon',
+#                  'Lesotho', 'Liberia',
+#                  'Libya', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Madagascar', 'Malawi', 'Malaysia', 'Maldives',
+#                  'Mali', 'Malta', 'Marshall Islands', 'Mauritania', 'Mauritius',
+#                  'Mexico', 'Micronesia, Federated States of', 'Moldova, Republic of', 'Monaco', 'Mongolia',
+#                  'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands',
+#                  'New Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'North Macedonia', 'Norway', 'Oman', 'Pakistan',
+#                  'Palau', 'Panama', 'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines', 'Poland', 'Portugal',
+#                  'Qatar', 'Romania', 'Russian Federation', 'Rwanda', 'Saint Kitts and Nevis', 'Saint Lucia',
+#                  'Saint Vincent and the Grenadines', 'Samoa', 'San Marino', 'Sao Tome and Principe', 'Saudi Arabia',
+#                  'Senegal', 'Seychelles', 'Sierra Leone', 'Singapore', 'Slovakia', 'Slovenia',
+#                  'Solomon Islands', 'Somalia', 'South Africa', 'Spain', 'Sri Lanka', 'Sudan',
+#                  'Suriname', 'Sweden', 'Switzerland', 'Syrian Arab Republic', 'Taiwan, Province of China',
+#                  'Tajikistan', 'Tanzania, United Republic of', 'Thailand',
+#                  'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Tuvalu', 'Uganda',
+#                  'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay', 'Uzbekistan',
+#                  'Vanuatu', 'Venezuela, Bolivarian Republic of', 'Viet Nam', 'Yemen', 'Zambia',
+#                  'Zimbabwe']
+#
+# hazard_list = ['relative_crop_yield']  # ['tropical_cyclone', 'river_flood', 'storm_europe', 'relative_crop_yield']
+# sector_list = ['agriculture']  # 'mining', 'manufacturing', 'service', 'electricity', 'agriculture'
+#
+# scenario = 'historical'  # 'rcp60', 'rcp26', 'rcp45','None', 'historical'
+# ref_year = '1971_2001'  # 'historical', 2040, 2060, 2080, 2020 #2020 works for river_flood only
+# n_sim_years = 100
+# io_approach = 'ghosh'
 
+config = {
+    "io_approach": "ghosh",
+    "n_sim_years": 100,
+    "runs": [
+        {
+            "hazard": "tropical_cyclone",
+            "sectors": ["agriculture"],
+            "countries": ["United States"],
+            "scenario_years": [
+                {"scenario": "None", "ref_year": "historical"},
+                {"scenario": "rcp26", "ref_year": "2040"},
+            ]
+        },
+        {
+            "hazard": "winterstorm",
+            "sectors": ["agriculture"],
+            "countries": ["United States"],
+            "scenario_years": [
+                {"scenario": "ssp126", "ref_year": "historical"},
+                {"scenario": "rcp26", "ref_year": "2040"},
+            ]
+        }
+    ]
+}
 
-
-#Check for country names with this website: https://github.com/flyingcircusio/pycountry/blob/main/src/pycountry/databases/iso3166-1.json
-
-country_list = ['United States']
-ALL_COUNTRIES = ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
-                  'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados',
-                  'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia, Plurinational State of',
-                  'Bosnia and Herzegovina', 'Botswana','Brazil', 'Brunei Darussalam', 'Bulgaria', 'Burkina Faso',
-                    'Burundi', 'Cabo Verde', 'Cambodia', 'Cameroon',
-                  'Canada', 'Central African Republic', 'Chad', 'Chile', 'China', 'Colombia', 'Comoros', 'Congo',
-                  'Congo, The Democratic Republic of the', 'Costa Rica', 'Croatia',"Côte d'Ivoire",
-                  'Cuba', 'Cyprus', 'Czechia', 'Denmark', 'Djibouti', 'Dominica', 'Dominican Republic',
-                  'Timor-Leste', 'Ecuador', 'Egypt', 'El Salvador', 'Equatorial Guinea', 'Eritrea',
-                  'Estonia', 'Eswatini', 'Ethiopia', 'Fiji', 'Finland', 'France', 'Gabon', 'Gambia', 'Georgia',
-                  'Germany', 'Ghana', 'Greece', 'Grenada', 'Guatemala', 'Guinea', 'Guinea-Bissau', 'Guyana', 'Haiti',
-                  'Honduras', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran, Islamic Republic of', 'Iraq',
-                  'Ireland','Israel','Italy', 'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati',
-                  "Korea, Democratic People's Republic of",
-                  'Korea, Republic of', 'Kuwait', 'Kyrgyzstan', "Lao People's Democratic Republic", 'Latvia', 'Lebanon',
-                  'Lesotho', 'Liberia',
-                  'Libya', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Madagascar', 'Malawi', 'Malaysia', 'Maldives',
-                  'Mali', 'Malta', 'Marshall Islands', 'Mauritania', 'Mauritius',
-                  'Mexico', 'Micronesia, Federated States of', 'Moldova, Republic of', 'Monaco', 'Mongolia',
-                  'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands',
-                  'New Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'North Macedonia', 'Norway', 'Oman', 'Pakistan',
-                  'Palau', 'Panama', 'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines', 'Poland', 'Portugal',
-                  'Qatar', 'Romania', 'Russian Federation', 'Rwanda', 'Saint Kitts and Nevis', 'Saint Lucia',
-                  'Saint Vincent and the Grenadines', 'Samoa', 'San Marino', 'Sao Tome and Principe', 'Saudi Arabia',
-                  'Senegal', 'Seychelles', 'Sierra Leone', 'Singapore', 'Slovakia', 'Slovenia',
-                  'Solomon Islands', 'Somalia', 'South Africa', 'Spain', 'Sri Lanka', 'Sudan',
-                  'Suriname', 'Sweden', 'Switzerland', 'Syrian Arab Republic', 'Taiwan, Province of China',
-                  'Tajikistan','Tanzania, United Republic of', 'Thailand',
-                  'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Tuvalu', 'Uganda',
-                  'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay', 'Uzbekistan',
-                  'Vanuatu', 'Venezuela, Bolivarian Republic of', 'Viet Nam', 'Yemen', 'Zambia',
-                  'Zimbabwe']
-
-hazard_list = ['relative_crop_yield']  # ['tropical_cyclone', 'river_flood', 'storm_europe', 'relative_crop_yield']
-sector_list = ['agriculture'] # 'mining', 'manufacturing', 'service', 'electricity', 'agriculture'
-
-scenario = 'historical' # 'rcp60', 'rcp26', 'rcp45','None', 'historical'
-ref_year = '1971_2001' # 'historical', 2040, 2060, 2080, 2020 #2020 works for river_flood only
-n_sim_years = 100
-io_approach = 'ghosh'
 
 # Agriculture
 # 2006_2099, 1976_2005
@@ -135,6 +162,7 @@ def calc_supply_chain_impacts(
         scenario,
         ref_year,
         n_sim_years,
+        io_approach,
         save_by_country=False,
         save_by_hazard=False,
         save_by_sector=False,
@@ -192,14 +220,12 @@ def calc_supply_chain_impacts(
     print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")
 
 
-if __name__ == "__main__":
-    #Added a loop to run for each country to have intermediate files
-
+def run_pipeline(country_list, hazard, sector_list, scenario, ref_year, n_sim_years, io_approach):
     for country in country_list:
         try:
             calc_supply_chain_impacts(
                 [country],  # replace by country_list if whole list should be calculated at once
-                hazard_list,
+                [hazard],
                 sector_list,
                 scenario,
                 ref_year,
@@ -208,8 +234,6 @@ if __name__ == "__main__":
             )
         except Exception as e:
             print(f"Could not calculate country {country} {sector_list} due to {e}")
-
-
 
     # Postprocessing to create the final files
     supchain = indirect.get_supply_chain()
@@ -227,3 +251,21 @@ if __name__ == "__main__":
         print(f"Adjusting {f} by {factor} to {f_out}")
         df.to_csv(f_out, index=False)
     print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")
+
+
+def run_pipeline_from_config(config):
+    for run in config["runs"]:
+        for scenario_year in run["scenario_years"]:
+            run_pipeline(
+                run["countries"],
+                run["hazard"],
+                run["sectors"],
+                scenario_year["scenario"],
+                scenario_year["ref_year"],
+                config["n_sim_years"],
+                config["io_approach"]
+            )
+
+
+if __name__ == "__main__":
+    run_pipeline_from_config(config)

--- a/analysis.py
+++ b/analysis.py
@@ -115,7 +115,7 @@ config = {
     "io_approach": "ghosh",
     "n_sim_years": 100,
     "runs": [
-        {
+        {   
             "hazard": "tropical_cyclone",
             "sectors": ["mining", "manufacturing", "service", "electricity","agriculture"],
             "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
@@ -302,6 +302,7 @@ config = {
                 # {"scenario": "ssp585", "ref_year": "present"},
             ]
         },
+
         {
             "hazard": "relative_crop_yield",
             "sectors": ["agriculture"],
@@ -427,22 +428,22 @@ def run_pipeline(country_list, hazard, sector_list, scenario, ref_year, n_sim_ye
         except Exception as e:
             print(f"Could not calculate country {country} {sector_list} due to {e}")
 
-    # Postprocessing to create the final files
-    # supchain = indirect.get_supply_chain()
-    # for f in glob.glob("results/*_*.csv"):
-    #     f_out = f.replace("results", "results_row_adjusted")
-    #     os.makedirs(os.path.dirname(f_out), exist_ok=True)
-    #
-    #     df = pd.read_csv(f)
-    #     iso_a3 = f.split("/")[-1].split("_")[-1].split(".")[0]
-    #     factor = indirect.get_country_modifier(supchain, iso_a3)
-    #     for col in df.columns:
-    #         if col.startswith("impact_"):
-    #             df[col] = df[col] * factor
-    #     # df["value"] = df["value"] * factor
-    #     print(f"Adjusting {f} by {factor} to {f_out}")
-    #     df.to_csv(f_out, index=False)
-    # print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")
+    # # Postprocessing to create the final files
+    supchain = indirect.get_supply_chain()
+    for f in glob.glob("results/*_*.csv"):
+        f_out = f.replace("results", "results_row_adjusted")
+        os.makedirs(os.path.dirname(f_out), exist_ok=True)
+
+        df = pd.read_csv(f)
+        iso_a3 = f.split("/")[-1].split("_")[-1].split(".")[0]
+        factor = indirect.get_country_modifier(supchain, iso_a3)
+        for col in df.columns:
+            if col.startswith("impact_"):
+                df[col] = df[col] * factor
+        # df["value"] = df["value"] * factor
+        print(f"Adjusting {f} by {factor} to {f_out}")
+        df.to_csv(f_out, index=False)
+    print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")
 
 
 def run_pipeline_from_config(config):
@@ -457,6 +458,7 @@ def run_pipeline_from_config(config):
                 config["n_sim_years"],
                 config["io_approach"]
             )
+
 
 
 if __name__ == "__main__":

--- a/analysis.py
+++ b/analysis.py
@@ -7,7 +7,7 @@ import indirect
 from calc_yearset import nccs_yearsets_simple
 # from utils.s3client import download_from_s3_bucket, upload_to_s3_bucket
 from direct import get_sector_exposure, nccs_direct_impacts_list_simple
-from indirect import dump_supchain_to_csv, supply_chain_climada
+from indirect import dump_supchain_to_csv, supply_chain_climada, dump_direct_to_csv
 
 """
 Climada API data availability: https://climada.ethz.ch/data-api/admin/docs 
@@ -115,7 +115,7 @@ config = {
     "io_approach": "ghosh",
     "n_sim_years": 100,
     "runs": [
-        {   
+        {
             "hazard": "tropical_cyclone",
             "sectors": ["mining", "manufacturing", "service", "electricity","agriculture"],
             "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
@@ -397,6 +397,18 @@ def calc_supply_chain_impacts(
                 impacted_sector=row['sector'],
                 io_approach=io_approach
             )
+            #save direct impacts to a csv
+            dump_direct_to_csv(
+                supchain=supchain,
+                haz_type=row['haz_type'],
+                sector=row['sector'],
+                scenario=scenario,
+                ref_year=ref_year,
+                country=row['country'],
+                n_sim=n_sim_years,
+                return_period=100,
+            )
+            #save indirect impacts to a csv
             dump_supchain_to_csv(
                 supchain=supchain,
                 haz_type=row['haz_type'],
@@ -408,6 +420,7 @@ def calc_supply_chain_impacts(
                 return_period=100,
                 io_approach=io_approach
             )
+
         except ValueError as e:
             print(f"Error calculating indirect impacts for {row['country']} {row['sector']}: {e}")
     print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")
@@ -428,7 +441,7 @@ def run_pipeline(country_list, hazard, sector_list, scenario, ref_year, n_sim_ye
         except Exception as e:
             print(f"Could not calculate country {country} {sector_list} due to {e}")
 
-    # # Postprocessing to create the final files
+    # Postprocessing to create the final files
     supchain = indirect.get_supply_chain()
     for f in glob.glob("results/*_*.csv"):
         f_out = f.replace("results", "results_row_adjusted")

--- a/analysis.py
+++ b/analysis.py
@@ -22,17 +22,6 @@ Tropical Cyclones:
     'event_type': ['synthetic', 'observed'],
     'climate_scenario': ['rcp26', 'rcp45', 'None', 'rcp60', 'rcp85']
 
-    combination that are allowed:
-    scenario = 'rcp26' & ref_year = 2040
-    scenario = 'rcp26' & ref_year = 2060
-    scenario = 'rcp26' & ref_year = 2080
-    scenario = 'rcp45' & ref_year = 2040
-    scenario = 'rcp45' & ref_year = 2060
-    scenario = 'rcp45' & ref_year = 2080
-    scenario = 'rcp60' & ref_year = 2040
-    scenario = 'rcp60' & ref_year = 2060
-    scenario = 'rcp60' & ref_year = 2080
-    scenario = 'None'  & ref_year = historical
     --> 'None' will use climate_scenario 'None' and historical will use '1980_2020' and will use "event_type": 
     "synthetic", could also use "observed"
 
@@ -41,24 +30,20 @@ River Flood:
     would be '1980_2000'
     'climate_scenario': ['rcp26', 'rcp85', 'None', 'rcp60'] # officialy in API, 'None' would be 'historical'
 
-    combination that are allowed:
-    scenario = 'rcp26' & ref_year = 2020
-    scenario = 'rcp26' & ref_year = 2040
-    scenario = 'rcp26' & ref_year = 2060
-    scenario = 'rcp26' & ref_year = 2080
-    scenario = 'rcp60' & ref_year = 2020
-    scenario = 'rcp60' & ref_year = 2040
-    scenario = 'rcp60' & ref_year = 2060
-    scenario = 'rcp60' & ref_year = 2080
-    scenario = 'rcp85' & ref_year = 2020
-    scenario = 'rcp85' & ref_year = 2040
-    scenario = 'rcp85' & ref_year = 2060 
-    scenario = 'rcp85' & ref_year = 2080
-    scenario = 'None'  & ref_year = historical
     --> 'None' will use climate_scenario 'historical' and ref_year = 'historical' will use '1980_2000'
 
 Storm Europe: 
-    hazard type: 'storm_europe', spatial coverage ? 
+    hazard type: 'storm_europe', spatial coverage 'Europe' 
+      {'res_km': ['100 km', '250 km', '500 km', '50 km'],
+ 'data_source': ['CMIP6', 'ERA5'],
+ 'climate_scenario': ['ssp585', 'ssp245', 'None', 'ssp370', 'ssp126'],
+ 'spatial_coverage': ['Europe'],
+ 'gcm': ['CMCC-CM2-SR5',  'HadGEM3-GC31-LL',  'ACCESS-ESM1-5',  'CMCC-ESM2',  'MPI-ESM1-2-HR',  'MIROC6',  'CanESM5',
+  'GFDL-CM4',  'UKESM1-0-LL',  'GISS-E2-1-G',  'INM-CM5-0',  'CNRM-ESM2-1',  'CNRM-CM6-1',  'ACCESS-CM2',  'MIROC-ES2L',
+  'INM-CM4-8',  'MRI-ESM2-0',  'IPSL-CM6A-LR',  'MPI-ESM1-2-LR',  'EC-Earth3-CC',  'FGOALS-g3',  'EC-Earth3',  'EC-Earth3-Veg-LR',
+  'AWI-CM-1-1-MR',  'CNRM-CM6-1-HR',  'KACE-1-0-G',  'BCC-CSM2-MR',  'EC-Earth3-Veg',  'NESM3',  'HadGEM3-GC31-MM']
+  
+  historical (1980-2010), and a future period (2070-2100) --> but the files on the api are not called as such
     
     
 Wildfire: 
@@ -72,11 +57,12 @@ Wildfire:
     --> even if another scenario is selected, it will just pick the historical one
     
 Agriculture: Relative Cropyield
-    hazard: 'relative_crop_yield'
+    hazard: 'relative_cropyield'
     sector: 'agriculture'
-    scenario = 'climate_scenario': ['historical', 'rcp60'] & ref_year = 'year_range': ['1971_2001', '1980_2012', 
-    '2006_2099', '1976_2005']    
-    hazard_list = ['relative_crop_yield']  # ['tropical_cyclone', 'river_flood', 'storm_europe', 'relative_crop_yield']
+    scenario = 'climate_scenario': ['historical', 'rcp60'] --> at the moment we use 'None' for historical
+    ref_year = 'year_range': ['1971_2001', '1980_2012', '2006_2099', '1976_2005']    --> at the moment we take 1971_2001 as historical
+     'crop': ['mai', 'soy', 'whe', 'ric'] --> at the moment we use wheat
+    'irrigation_status': ['firr', 'noirr'],
 """
 
 # Check for country names with this website:
@@ -131,29 +117,235 @@ config = {
     "runs": [
         {
             "hazard": "tropical_cyclone",
-            "sectors": ["agriculture"],
-            "countries": ["United States"],
+            "sectors": ["mining", "manufacturing", "service", "electricity","agriculture"],
+            "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
+                 'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados',
+                 'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia, Plurinational State of',
+                 'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei Darussalam', 'Bulgaria', 'Burkina Faso',
+                 'Burundi', 'Cabo Verde', 'Cambodia', 'Cameroon',
+                 'Canada', 'Central African Republic', 'Chad', 'Chile', 'China', 'Colombia', 'Comoros', 'Congo',
+                 'Congo, The Democratic Republic of the', 'Costa Rica', 'Croatia', "Côte d'Ivoire",
+                 'Cuba', 'Cyprus', 'Czechia', 'Denmark', 'Djibouti', 'Dominica', 'Dominican Republic',
+                 'Timor-Leste', 'Ecuador', 'Egypt', 'El Salvador', 'Equatorial Guinea', 'Eritrea',
+                 'Estonia', 'Eswatini', 'Ethiopia', 'Fiji', 'Finland', 'France', 'Gabon', 'Gambia', 'Georgia',
+                 'Germany', 'Ghana', 'Greece', 'Grenada', 'Guatemala', 'Guinea', 'Guinea-Bissau', 'Guyana', 'Haiti',
+                 'Honduras', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran, Islamic Republic of', 'Iraq',
+                 'Ireland', 'Israel', 'Italy', 'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati',
+                 "Korea, Democratic People's Republic of",
+                 'Korea, Republic of', 'Kuwait', 'Kyrgyzstan', "Lao People's Democratic Republic", 'Latvia',
+                 'Lebanon',
+                 'Lesotho', 'Liberia',
+                 'Libya', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Madagascar', 'Malawi', 'Malaysia', 'Maldives',
+                 'Mali', 'Malta', 'Marshall Islands', 'Mauritania', 'Mauritius',
+                 'Mexico', 'Micronesia, Federated States of', 'Moldova, Republic of', 'Monaco', 'Mongolia',
+                 'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands',
+                 'New Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'North Macedonia', 'Norway', 'Oman', 'Pakistan',
+                 'Palau', 'Panama', 'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines', 'Poland', 'Portugal',
+                 'Qatar', 'Romania', 'Russian Federation', 'Rwanda', 'Saint Kitts and Nevis', 'Saint Lucia',
+                 'Saint Vincent and the Grenadines', 'Samoa', 'San Marino', 'Sao Tome and Principe', 'Saudi Arabia',
+                 'Senegal', 'Seychelles', 'Sierra Leone', 'Singapore', 'Slovakia', 'Slovenia',
+                 'Solomon Islands', 'Somalia', 'South Africa', 'Spain', 'Sri Lanka', 'Sudan',
+                 'Suriname', 'Sweden', 'Syrian Arab Republic', 'Taiwan, Province of China',
+                 'Tajikistan', 'Tanzania, United Republic of', 'Thailand',
+                 'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Tuvalu', 'Uganda',
+                 'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay', 'Uzbekistan',
+                 'Vanuatu', 'Venezuela, Bolivarian Republic of', 'Viet Nam', 'Yemen', 'Zambia',
+                 'Zimbabwe'],
             "scenario_years": [
                 {"scenario": "None", "ref_year": "historical"},
-                {"scenario": "rcp26", "ref_year": "2040"},
+                # {"scenario": "rcp26", "ref_year": "2040"}, #have the run for this for some countries
+                # {"scenario": "rcp26", "ref_year": "2060"},
+                # {"scenario": "rcp26", "ref_year": "2080"},
+                # {"scenario": "rcp45", "ref_year": "2040"},
+                # {"scenario": "rcp45", "ref_year": "2060"},
+                # {"scenario": "rcp45", "ref_year": "2080"},
+                # {"scenario": "rcp60", "ref_year": "2040"},
+                {"scenario": "rcp60", "ref_year": "2060"},
+                # {"scenario": "rcp60", "ref_year": "2080"},
+                # {"scenario": "rcp85", "ref_year": "2040"},
+                # {"scenario": "rcp85", "ref_year": "2060"}, #have the run for this for some countries
             ]
         },
         {
-            "hazard": "winterstorm",
-            "sectors": ["agriculture"],
-            "countries": ["United States"],
+            "hazard": "river_flood",
+            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture"],
+            "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
+                 'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados',
+                 'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia, Plurinational State of',
+                 'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei Darussalam', 'Bulgaria', 'Burkina Faso',
+                 'Burundi', 'Cabo Verde', 'Cambodia', 'Cameroon',
+                 'Canada', 'Central African Republic', 'Chad', 'Chile', 'China', 'Colombia', 'Comoros', 'Congo',
+                 'Congo, The Democratic Republic of the', 'Costa Rica', 'Croatia', "Côte d'Ivoire",
+                 'Cuba', 'Cyprus', 'Czechia', 'Denmark', 'Djibouti', 'Dominica', 'Dominican Republic',
+                 'Timor-Leste', 'Ecuador', 'Egypt', 'El Salvador', 'Equatorial Guinea', 'Eritrea',
+                 'Estonia', 'Eswatini', 'Ethiopia', 'Fiji', 'Finland', 'France', 'Gabon', 'Gambia', 'Georgia',
+                 'Germany', 'Ghana', 'Greece', 'Grenada', 'Guatemala', 'Guinea', 'Guinea-Bissau', 'Guyana', 'Haiti',
+                 'Honduras', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran, Islamic Republic of', 'Iraq',
+                 'Ireland', 'Israel', 'Italy', 'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati',
+                 "Korea, Democratic People's Republic of",
+                 'Korea, Republic of', 'Kuwait', 'Kyrgyzstan', "Lao People's Democratic Republic", 'Latvia',
+                 'Lebanon',
+                 'Lesotho', 'Liberia',
+                 'Libya', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Madagascar', 'Malawi', 'Malaysia', 'Maldives',
+                 'Mali', 'Malta', 'Marshall Islands', 'Mauritania', 'Mauritius',
+                 'Mexico', 'Micronesia, Federated States of', 'Moldova, Republic of', 'Monaco', 'Mongolia',
+                 'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands',
+                 'New Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'North Macedonia', 'Norway', 'Oman', 'Pakistan',
+                 'Palau', 'Panama', 'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines', 'Poland', 'Portugal',
+                 'Qatar', 'Romania', 'Russian Federation', 'Rwanda', 'Saint Kitts and Nevis', 'Saint Lucia',
+                 'Saint Vincent and the Grenadines', 'Samoa', 'San Marino', 'Sao Tome and Principe', 'Saudi Arabia',
+                 'Senegal', 'Seychelles', 'Sierra Leone', 'Singapore', 'Slovakia', 'Slovenia',
+                 'Solomon Islands', 'Somalia', 'South Africa', 'Spain', 'Sri Lanka', 'Sudan',
+                 'Suriname', 'Sweden', 'Syrian Arab Republic', 'Taiwan, Province of China',
+                 'Tajikistan', 'Tanzania, United Republic of', 'Thailand',
+                 'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Tuvalu', 'Uganda',
+                 'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay', 'Uzbekistan',
+                 'Vanuatu', 'Venezuela, Bolivarian Republic of', 'Viet Nam', 'Yemen', 'Zambia',
+                 'Zimbabwe'],
             "scenario_years": [
-                {"scenario": "ssp126", "ref_year": "historical"},
-                {"scenario": "rcp26", "ref_year": "2040"},
+                {"scenario": "None", "ref_year": "historical"},
+                # {"scenario": "rcp26", "ref_year": 2020},
+                # {"scenario": "rcp26", "ref_year": 2040}, #have the run for this
+                # {"scenario": "rcp26", "ref_year": 2060},
+                # # {"scenario": "rcp26", "ref_year": 2080},
+                # {"scenario": "rcp60", "ref_year": 2020},
+                # {"scenario": "rcp60", "ref_year": 2040},
+                {"scenario": "rcp60", "ref_year": 2060},
+                # {"scenario": "rcp60", "ref_year": 2080},
+                # {"scenario": "rcp85", "ref_year": 2020},
+                # {"scenario": "rcp85", "ref_year": 2040},
+                # {"scenario": "rcp85", "ref_year": 2060}, #have the run for this
+                # {"scenario": "rcp85", "ref_year": 2080},
+            ]
+        },
+        {
+            "hazard": "wildfire",
+            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture"],
+            "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
+                 'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados',
+                 'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia, Plurinational State of',
+                 'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei Darussalam', 'Bulgaria', 'Burkina Faso',
+                 'Burundi', 'Cabo Verde', 'Cambodia', 'Cameroon',
+                 'Canada', 'Central African Republic', 'Chad', 'Chile', 'China', 'Colombia', 'Comoros', 'Congo',
+                 'Congo, The Democratic Republic of the', 'Costa Rica', 'Croatia', "Côte d'Ivoire",
+                 'Cuba', 'Cyprus', 'Czechia', 'Denmark', 'Djibouti', 'Dominica', 'Dominican Republic',
+                 'Timor-Leste', 'Ecuador', 'Egypt', 'El Salvador', 'Equatorial Guinea', 'Eritrea',
+                 'Estonia', 'Eswatini', 'Ethiopia', 'Fiji', 'Finland', 'France', 'Gabon', 'Gambia', 'Georgia',
+                 'Germany', 'Ghana', 'Greece', 'Grenada', 'Guatemala', 'Guinea', 'Guinea-Bissau', 'Guyana', 'Haiti',
+                 'Honduras', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran, Islamic Republic of', 'Iraq',
+                 'Ireland', 'Israel', 'Italy', 'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati',
+                 "Korea, Democratic People's Republic of",
+                 'Korea, Republic of', 'Kuwait', 'Kyrgyzstan', "Lao People's Democratic Republic", 'Latvia',
+                 'Lebanon',
+                 'Lesotho', 'Liberia',
+                 'Libya', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Madagascar', 'Malawi', 'Malaysia', 'Maldives',
+                 'Mali', 'Malta', 'Marshall Islands', 'Mauritania', 'Mauritius',
+                 'Mexico', 'Micronesia, Federated States of', 'Moldova, Republic of', 'Monaco', 'Mongolia',
+                 'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands',
+                 'New Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'North Macedonia', 'Norway', 'Oman', 'Pakistan',
+                 'Palau', 'Panama', 'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines', 'Poland', 'Portugal',
+                 'Qatar', 'Romania', 'Russian Federation', 'Rwanda', 'Saint Kitts and Nevis', 'Saint Lucia',
+                 'Saint Vincent and the Grenadines', 'Samoa', 'San Marino', 'Sao Tome and Principe', 'Saudi Arabia',
+                 'Senegal', 'Seychelles', 'Sierra Leone', 'Singapore', 'Slovakia', 'Slovenia',
+                 'Solomon Islands', 'Somalia', 'South Africa', 'Spain', 'Sri Lanka', 'Sudan',
+                 'Suriname', 'Sweden', 'Syrian Arab Republic', 'Taiwan, Province of China',
+                 'Tajikistan', 'Tanzania, United Republic of', 'Thailand',
+                 'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Tuvalu', 'Uganda',
+                 'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay', 'Uzbekistan',
+                 'Vanuatu', 'Venezuela, Bolivarian Republic of', 'Viet Nam', 'Yemen', 'Zambia',
+                 'Zimbabwe'],
+            "scenario_years": [
+                {"scenario": "None", "ref_year": "historical"},
+            ]
+        },
+        {
+            "hazard": "storm_europe",
+            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture"],
+            "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
+                 'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados',
+                 'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia, Plurinational State of',
+                 'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei Darussalam', 'Bulgaria', 'Burkina Faso',
+                 'Burundi', 'Cabo Verde', 'Cambodia', 'Cameroon',
+                 'Canada', 'Central African Republic', 'Chad', 'Chile', 'China', 'Colombia', 'Comoros', 'Congo',
+                 'Congo, The Democratic Republic of the', 'Costa Rica', 'Croatia', "Côte d'Ivoire",
+                 'Cuba', 'Cyprus', 'Czechia', 'Denmark', 'Djibouti', 'Dominica', 'Dominican Republic',
+                 'Timor-Leste', 'Ecuador', 'Egypt', 'El Salvador', 'Equatorial Guinea', 'Eritrea',
+                 'Estonia', 'Eswatini', 'Ethiopia', 'Fiji', 'Finland', 'France', 'Gabon', 'Gambia', 'Georgia',
+                 'Germany', 'Ghana', 'Greece', 'Grenada', 'Guatemala', 'Guinea', 'Guinea-Bissau', 'Guyana', 'Haiti',
+                 'Honduras', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran, Islamic Republic of', 'Iraq',
+                 'Ireland', 'Israel', 'Italy', 'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati',
+                 "Korea, Democratic People's Republic of",
+                 'Korea, Republic of', 'Kuwait', 'Kyrgyzstan', "Lao People's Democratic Republic", 'Latvia',
+                 'Lebanon',
+                 'Lesotho', 'Liberia',
+                 'Libya', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Madagascar', 'Malawi', 'Malaysia', 'Maldives',
+                 'Mali', 'Malta', 'Marshall Islands', 'Mauritania', 'Mauritius',
+                 'Mexico', 'Micronesia, Federated States of', 'Moldova, Republic of', 'Monaco', 'Mongolia',
+                 'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands',
+                 'New Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'North Macedonia', 'Norway', 'Oman', 'Pakistan',
+                 'Palau', 'Panama', 'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines', 'Poland', 'Portugal',
+                 'Qatar', 'Romania', 'Russian Federation', 'Rwanda', 'Saint Kitts and Nevis', 'Saint Lucia',
+                 'Saint Vincent and the Grenadines', 'Samoa', 'San Marino', 'Sao Tome and Principe', 'Saudi Arabia',
+                 'Senegal', 'Seychelles', 'Sierra Leone', 'Singapore', 'Slovakia', 'Slovenia',
+                 'Solomon Islands', 'Somalia', 'South Africa', 'Spain', 'Sri Lanka', 'Sudan',
+                 'Suriname', 'Sweden', 'Syrian Arab Republic', 'Taiwan, Province of China',
+                 'Tajikistan', 'Tanzania, United Republic of', 'Thailand',
+                 'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Tuvalu', 'Uganda',
+                 'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay', 'Uzbekistan',
+                 'Vanuatu', 'Venezuela, Bolivarian Republic of', 'Viet Nam', 'Yemen', 'Zambia',
+                 'Zimbabwe'],
+            "scenario_years": [
+                {"scenario": "None", "ref_year": "present"},
+                # {"scenario": "ssp126", "ref_year": "present"},
+                # {"scenario": "ssp245", "ref_year": "present"},
+                # {"scenario": "ssp370", "ref_year": "present"},
+                # {"scenario": "ssp585", "ref_year": "present"},
+            ]
+        },
+        {
+            "hazard": "relative_crop_yield",
+            "sectors": ["agriculture"],
+            "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
+                 'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados',
+                 'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia, Plurinational State of',
+                 'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei Darussalam', 'Bulgaria', 'Burkina Faso',
+                 'Burundi', 'Cabo Verde', 'Cambodia', 'Cameroon',
+                 'Canada', 'Central African Republic', 'Chad', 'Chile', 'China', 'Colombia', 'Comoros', 'Congo',
+                 'Congo, The Democratic Republic of the', 'Costa Rica', 'Croatia', "Côte d'Ivoire",
+                 'Cuba', 'Cyprus', 'Czechia', 'Denmark', 'Djibouti', 'Dominica', 'Dominican Republic',
+                 'Timor-Leste', 'Ecuador', 'Egypt', 'El Salvador', 'Equatorial Guinea', 'Eritrea',
+                 'Estonia', 'Eswatini', 'Ethiopia', 'Fiji', 'Finland', 'France', 'Gabon', 'Gambia', 'Georgia',
+                 'Germany', 'Ghana', 'Greece', 'Grenada', 'Guatemala', 'Guinea', 'Guinea-Bissau', 'Guyana', 'Haiti',
+                 'Honduras', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran, Islamic Republic of', 'Iraq',
+                 'Ireland', 'Israel', 'Italy', 'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati',
+                 "Korea, Democratic People's Republic of",
+                 'Korea, Republic of', 'Kuwait', 'Kyrgyzstan', "Lao People's Democratic Republic", 'Latvia',
+                 'Lebanon',
+                 'Lesotho', 'Liberia',
+                 'Libya', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Madagascar', 'Malawi', 'Malaysia', 'Maldives',
+                 'Mali', 'Malta', 'Marshall Islands', 'Mauritania', 'Mauritius',
+                 'Mexico', 'Micronesia, Federated States of', 'Moldova, Republic of', 'Monaco', 'Mongolia',
+                 'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands',
+                 'New Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'North Macedonia', 'Norway', 'Oman', 'Pakistan',
+                 'Palau', 'Panama', 'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines', 'Poland', 'Portugal',
+                 'Qatar', 'Romania', 'Russian Federation', 'Rwanda', 'Saint Kitts and Nevis', 'Saint Lucia',
+                 'Saint Vincent and the Grenadines', 'Samoa', 'San Marino', 'Sao Tome and Principe', 'Saudi Arabia',
+                 'Senegal', 'Seychelles', 'Sierra Leone', 'Singapore', 'Slovakia', 'Slovenia',
+                 'Solomon Islands', 'Somalia', 'South Africa', 'Spain', 'Sri Lanka', 'Sudan',
+                 'Suriname', 'Sweden', 'Syrian Arab Republic', 'Taiwan, Province of China',
+                 'Tajikistan', 'Tanzania, United Republic of', 'Thailand',
+                 'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Tuvalu', 'Uganda',
+                 'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay', 'Uzbekistan',
+                 'Vanuatu', 'Venezuela, Bolivarian Republic of', 'Viet Nam', 'Yemen', 'Zambia',
+                 'Zimbabwe'],
+            "scenario_years": [
+                {"scenario": "None", "ref_year": "historical"},
+                {"scenario": "rcp60", "ref_year": "2006_2099"},
             ]
         }
     ]
 }
 
-
-# Agriculture
-# 2006_2099, 1976_2005
-# historical, rcp60
 
 def calc_supply_chain_impacts(
         country_list,
@@ -236,21 +428,21 @@ def run_pipeline(country_list, hazard, sector_list, scenario, ref_year, n_sim_ye
             print(f"Could not calculate country {country} {sector_list} due to {e}")
 
     # Postprocessing to create the final files
-    supchain = indirect.get_supply_chain()
-    for f in glob.glob("results/*_*.csv"):
-        f_out = f.replace("results", "results_row_adjusted")
-        os.makedirs(os.path.dirname(f_out), exist_ok=True)
-
-        df = pd.read_csv(f)
-        iso_a3 = f.split("/")[-1].split("_")[-1].split(".")[0]
-        factor = indirect.get_country_modifier(supchain, iso_a3)
-        for col in df.columns:
-            if col.startswith("impact_"):
-                df[col] = df[col] * factor
-        # df["value"] = df["value"] * factor
-        print(f"Adjusting {f} by {factor} to {f_out}")
-        df.to_csv(f_out, index=False)
-    print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")
+    # supchain = indirect.get_supply_chain()
+    # for f in glob.glob("results/*_*.csv"):
+    #     f_out = f.replace("results", "results_row_adjusted")
+    #     os.makedirs(os.path.dirname(f_out), exist_ok=True)
+    #
+    #     df = pd.read_csv(f)
+    #     iso_a3 = f.split("/")[-1].split("_")[-1].split(".")[0]
+    #     factor = indirect.get_country_modifier(supchain, iso_a3)
+    #     for col in df.columns:
+    #         if col.startswith("impact_"):
+    #             df[col] = df[col] * factor
+    #     # df["value"] = df["value"] * factor
+    #     print(f"Adjusting {f} by {factor} to {f_out}")
+    #     df.to_csv(f_out, index=False)
+    # print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")
 
 
 def run_pipeline_from_config(config):

--- a/dashboard.py
+++ b/dashboard.py
@@ -332,24 +332,23 @@ def on_io_approach_changed(attr, old, new):
 select_hazard_type = Select(
     title="Hazard Type",
     options=sorted(HAZARD_TYPES),
-    value=selected_hazard_type, width=200)
+    value=selected_hazard_type,
+    width=200)
 select_hazard_type.on_change("value", on_hazard_type_changed)
 
 select_source_sector = Select(
     title="Impacted Sector",
     options=sorted(IMPACTED_SECTORS),
     value=selected_impacted_sector,
-    width=200,
-)
+    width=200)
 select_source_sector.on_change("value", on_impacted_sector_changed)
 select_source_sector.sizing_mode = "fixed"
 
 select_metric = Select(
     title="Metric",
     options=sorted(METRICS),
-    value=selected_impacted_sector,
-    width=200,
-)
+    value=selected_metric,
+    width=200)
 select_metric.on_change("value", on_metric_changed)
 select_metric.sizing_mode = "fixed"
 
@@ -357,27 +356,24 @@ select_scenario = Select(
     title="Scenario",
     options=sorted(SCENARIOS),
     value=selected_scenario,
-    width=200,
-)
-select_scenario.on_change("value", on_metric_changed)
+    width=200)
+select_scenario.on_change("value", on_scenario_changed)
 select_scenario.sizing_mode = "fixed"
 
 select_ref_year = Select(
     title="Year",
     options=sorted(REF_YEARS),
     value=selected_ref_year,
-    width=200,
-)
-select_ref_year.on_change("value", on_metric_changed)
+    width=200)
+select_ref_year.on_change("value", on_ref_year_changed)
 select_ref_year.sizing_mode = "fixed"
 
 select_io_approach = Select(
     title="IO Approach",
     options=sorted(IO_APPROACH),
     value=selected_io_approach,
-    width=200,
-)
-select_io_approach.on_change("value", on_metric_changed)
+    width=200)
+select_io_approach.on_change("value", on_io_approach_changed)
 select_io_approach.sizing_mode = "fixed"
 
 # Country Plot

--- a/direct.py
+++ b/direct.py
@@ -64,7 +64,7 @@ def nccs_direct_impacts_list_simple(hazard_list, sector_list, country_list, scen
 def nccs_direct_impacts_simple(haz_type, sector, country, scenario, ref_year):
     # Country names can be checked here: https://github.com/flyingcircusio/pycountry/blob/main/src/pycountry
     # /databases/iso3166-1.json
-    print(f"Calculating direct impacts for {country} {sector} {haz_type}")
+    print(f"Calculating direct impacts for {country} {sector} {haz_type} {scenario} {ref_year}")
     country_iso3alpha = pycountry.countries.get(name=country).alpha_3
     haz = get_hazard(haz_type, country_iso3alpha, scenario, ref_year)
     exp = get_sector_exposure(sector, country)  # was originally here
@@ -148,7 +148,7 @@ def get_sector_impf_rf(country_iso3alpha):
 # for wildfire, not sure if it is working
 def get_sector_impf_wf():
     impf = ImpfWildfire.from_default_FIRMS()
-    impf.haz_type = 'WFseason'
+    impf.haz_type = 'WFseason' #TODO there is a warning when running the code that the haz_type is set to WFsingle
     return impf
 
 
@@ -208,17 +208,26 @@ def get_hazard(haz_type, country_iso3alpha, scenario, ref_year):
             haz_type, properties={
                 'spatial_coverage': 'Europe',
                 'gcm': 'EC-Earth3-Veg',
-                'climate_scenario': WS_SCENARIO_LOOKUP[scenario]
+                #'climate_scenario': WS_SCENARIO_LOOKUP[scenario]
+                'climate_scenario': scenario
             }
         )
         # TODO filter to bounding box
+    # TODO currently always returns the same hazard
+
     elif haz_type == "relative_crop_yield":
         # TODO currently always returns the same hazard
-
-        return agriculture.get_hazard(
-            country=country_iso3alpha,
-            year_range=ref_year,
-            scenario=scenario
-        )
+        if scenario == 'None' and ref_year=="historical":
+            return agriculture.get_hazard(
+                country=country_iso3alpha,
+                year_range="1971_2001",
+                scenario="historical"
+            )
+        else:
+            return agriculture.get_hazard(
+                country=country_iso3alpha,
+                year_range=ref_year,
+                scenario=scenario
+            )
     else:
         raise ValueError(f'Unrecognised haz_type variable: {haz_type}.\nPlease use one of: {list(HAZ_TYPE_LOOKUP.keys())}')

--- a/indirect.py
+++ b/indirect.py
@@ -67,44 +67,71 @@ def supply_chain_climada(exposure, direct_impact, io_approach, impacted_sector="
 """
 trial not sure if it will work
 """
-# def dump_direct_to_csv(supchain, haz_type, sector, scenario, ref_year,country, n_sim=100, return_period=100):
-#     index_rp = np.floor(n_sim / return_period).astype(int) - 1
-#     direct_impacts=[]
-#     for (sec, v) in supchain.secs_shock.loc[:, (country, supchain.impacted_secs)].items():
-#         rp_value = v.sort_values(ascending=False).iloc[index_rp]
-#         mean = v.sum() / n_sim
-#         max_val = v.max()
-#         obj = {
-#             "sector": sec[1],
-#             #"value": mean,
-#             "impact_max": max_val,
-#             # "rel_impact_max":(max_val/lookup[sec[1]])*100,
-#             "impact_aai": mean,
-#             # "rel_impact_aai": (mean/lookup[sec[1]]*100),
-#             f"impact_rp_{return_period}": rp_value,
-#             # f"rel_impact_rp_{return_period}": (rp_value/lookup[sec[1]])*100,
-#             "hazard_type": haz_type,
-#             "sector_of_impact": sector,
-#             "scenario": scenario,
-#             "ref_year": ref_year,
-#             "country_of_impact": country,
-#
-#         }
-#         direct_impacts.append(obj)
-#     df_direct = pd.DataFrame(direct_impacts)
-#     # newly added to get ISO3 code
-#     country_iso3alpha = pycountry.countries.get(name=country).alpha_3  # f"_{country.replace(' ', '_')[:15]}" \
-#     path = f"{os.path.dirname(__file__)}/results_direct/" \
-#            f"direct_impacts" \
-#            f"_{haz_type}" \
-#            f"_{sector.replace(' ', '_')[:15]}" \
-#            f"_{scenario}" \
-#            f"_{ref_year}" \
-#            f"_{country_iso3alpha}" \
-#            f".csv"
-#
-#     df_direct.to_csv(path)
-#     return path
+def dump_direct_to_csv(supchain, haz_type, sector, scenario, ref_year,country, n_sim=100, return_period=100):
+    index_rp = np.floor(n_sim / return_period).astype(int) - 1
+    direct_impacts=[]
+    sec_range = SUPER_SEC[sector]
+    impacted_secs = supchain.mriot.get_sectors()[sec_range].tolist()
+    country_iso3alpha = pycountry.countries.get(name=country).alpha_3
+    secs_prod = supchain.mriot.x.loc[(country_iso3alpha, impacted_secs), :]
+    # create a lookup table for each sector and its total production
+    lookup = {}
+    for idx, row in secs_prod.iterrows():
+        lookup[idx] = row["total production"]
+    for (sec, v) in supchain.secs_shock.loc[:, (country_iso3alpha, impacted_secs)].items():
+        rp_value = v.sort_values(ascending=False).iloc[index_rp]
+        mean = v.sum() / n_sim
+        max_val = v.max()
+        # Check if the denominator is non-zero before performing division
+        if lookup[sec] != 0:
+            obj = {
+                "sector": sec[1],
+                "total_sectorial_production_mriot": lookup[sec],
+                "impact_max": max_val,
+                "rel_impact_max_%": (max_val / lookup[sec]) * 100 if max_val != 0 else 0,
+                "impact_aai": mean,
+                "rel_impact_aai_%": (mean / lookup[sec]) * 100 if mean != 0 else 0,
+                f"impact_rp_{return_period}": rp_value,
+                f"rel_impact_rp_{return_period}_%": (rp_value / lookup[sec]) * 100 if rp_value != 0 else 0,
+                "hazard_type": haz_type,
+                "sector_of_impact": sector,
+                "scenario": scenario,
+                "ref_year": ref_year,
+                "country_of_impact": country,
+            }
+            direct_impacts.append(obj)
+        else:
+            # Handle the case where the denominator is zero
+            obj = {
+                "sector": sec[1],
+                "total_sectorial_production_mriot": lookup[sec],
+                "impact_max": max_val,
+                "rel_impact_max_%": 0,  # Set to 0 to avoid division by zero
+                "impact_aai": mean,
+                "rel_impact_aai_%": 0,  # Set to 0 to avoid division by zero
+                f"impact_rp_{return_period}": rp_value,
+                f"rel_impact_rp_{return_period}_%": 0,  # Set to 0 to avoid division by zero
+                "hazard_type": haz_type,
+                "sector_of_impact": sector,
+                "scenario": scenario,
+                "ref_year": ref_year,
+                "country_of_impact": country,
+            }
+            direct_impacts.append(obj)
+    df_direct = pd.DataFrame(direct_impacts)
+    # newly added to get ISO3 code
+    country_iso3alpha = pycountry.countries.get(name=country).alpha_3  # f"_{country.replace(' ', '_')[:15]}" \
+    path = f"{os.path.dirname(__file__)}/results_direct/" \
+           f"direct_impacts" \
+           f"_{haz_type}" \
+           f"_{sector.replace(' ', '_')[:15]}" \
+           f"_{scenario}" \
+           f"_{ref_year}" \
+           f"_{country_iso3alpha}" \
+           f".csv"
+
+    df_direct.to_csv(path)
+    return path
 
 
 def dump_supchain_to_csv(supchain, haz_type, sector, scenario, ref_year, country, io_approach, n_sim=100, return_period=100):

--- a/indirect.py
+++ b/indirect.py
@@ -63,6 +63,48 @@ def supply_chain_climada(exposure, direct_impact, io_approach, impacted_sector="
     )
     return supchain
 
+# TODO include another dump to csv function to store the direct impacts
+"""
+trial not sure if it will work
+"""
+# def dump_direct_to_csv(supchain, haz_type, sector, scenario, ref_year,country, n_sim=100, return_period=100):
+#     index_rp = np.floor(n_sim / return_period).astype(int) - 1
+#     direct_impacts=[]
+#     for (sec, v) in supchain.secs_shock.loc[:, (country, supchain.impacted_secs)].items():
+#         rp_value = v.sort_values(ascending=False).iloc[index_rp]
+#         mean = v.sum() / n_sim
+#         max_val = v.max()
+#         obj = {
+#             "sector": sec[1],
+#             #"value": mean,
+#             "impact_max": max_val,
+#             # "rel_impact_max":(max_val/lookup[sec[1]])*100,
+#             "impact_aai": mean,
+#             # "rel_impact_aai": (mean/lookup[sec[1]]*100),
+#             f"impact_rp_{return_period}": rp_value,
+#             # f"rel_impact_rp_{return_period}": (rp_value/lookup[sec[1]])*100,
+#             "hazard_type": haz_type,
+#             "sector_of_impact": sector,
+#             "scenario": scenario,
+#             "ref_year": ref_year,
+#             "country_of_impact": country,
+#
+#         }
+#         direct_impacts.append(obj)
+#     df_direct = pd.DataFrame(direct_impacts)
+#     # newly added to get ISO3 code
+#     country_iso3alpha = pycountry.countries.get(name=country).alpha_3  # f"_{country.replace(' ', '_')[:15]}" \
+#     path = f"{os.path.dirname(__file__)}/results_direct/" \
+#            f"direct_impacts" \
+#            f"_{haz_type}" \
+#            f"_{sector.replace(' ', '_')[:15]}" \
+#            f"_{scenario}" \
+#            f"_{ref_year}" \
+#            f"_{country_iso3alpha}" \
+#            f".csv"
+#
+#     df_direct.to_csv(path)
+#     return path
 
 
 def dump_supchain_to_csv(supchain, haz_type, sector, scenario, ref_year, country, io_approach, n_sim=100, return_period=100):


### PR DESCRIPTION
@ghalter could you please check out this branch again?

The configurations are added and run the code with it, so this works perfectly fine and does not require checking.


To check:

- [ ] Addition to saving direct impacts for each country/hazard/sector combination to a csv. I added another function (dump_direct_to_csv) to save the intermediate csv files. I also tested it and it should work. Location: indirect.py (line 70-120)

Addition needed:

- [ ] save the intermediate file to the s3 bucket
- [ ] save csv files to the s3 bucket