### PR TITLE
.wip(direct outputs): same methods as before doing some double cheks

### DIFF
--- a/pipeline/direct/agriculture.py
+++ b/pipeline/direct/agriculture.py
@@ -54,7 +54,7 @@ def get_impf_set_tc():
 def get_hazard(country,
                year_range,
                scenario: typing.Literal["historical", "rcp60"] = "historical",
-               crop_type: CropType = "whe",
+               crop_type: CropType = "whe", #mai instead of wheat
                irr: IrrigationType = "firr"):
     # TODO how to map the year to the years in this model
     # TODO What about the firr and noirr?

--- a/run_configurations/config.py
+++ b/run_configurations/config.py
@@ -4,13 +4,13 @@ either not yet fully developed (windstorms) or has not yet been decided which co
 """
 
 CONFIG = {
-    "run_title": "test_run",
+    "run_title": "best_guesstimate_17_01_2024",
     "io_approach": "ghosh",
     "n_sim_years": 100,
     "runs": [
         {
             "hazard": "tropical_cyclone",
-            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture"],
+            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture","forestry"],
             "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
                           'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh',
                           'Barbados',
@@ -70,7 +70,7 @@ CONFIG = {
         },
         {
             "hazard": "river_flood",
-            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture"],
+            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture","forestry"],
             "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
                           'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh',
                           'Barbados',
@@ -131,7 +131,7 @@ CONFIG = {
         },
         {
             "hazard": "wildfire",
-            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture"],
+            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture","forestry"],
             "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
                           'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh',
                           'Barbados',
@@ -180,7 +180,7 @@ CONFIG = {
         },
         {
             "hazard": "storm_europe",
-            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture"],
+            "sectors": ["mining", "manufacturing", "service", "electricity", "agriculture","forestry"],
             "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
                           'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh',
                           'Barbados',

--- a/run_configurations/test_config.py
+++ b/run_configurations/test_config.py
@@ -11,7 +11,7 @@ CONFIG = {
         {
             "hazard": "tropical_cyclone",
             "sectors": ["manufacturing"],
-            "countries": ['Fiji','Germany','Brazil'],
+            "countries": ['Fiji', 'United States', 'Germany'],
             "scenario_years": [
                 {"scenario": "rcp26", "ref_year": "2060"}
 


### PR DESCRIPTION
@ghalter I checked now again the supply chain tutorial and also some documentation and decided to stay on the method we had this morning. Changing to secs_imp (instead of secs_shock) would neglect the integration of the exposure/impact ratio, which is actually used to feed the supply chain module with the direct impact. Therefore, I also agree with the method of multiplying this ratio with the total production of each sector (as it was before) to get the direct impact.

Using secs_imp would also create the unit problem, whereas using the ration (and multiplying it with the mriot neglects this)

Nevertheless, it might be good if you could check this again to be (hopefully) finally sure that we extract everything correctly. 