### PR TITLE
Make yearset generation reproducible

### DIFF
--- a/pipeline/direct/calc_yearset.py
+++ b/pipeline/direct/calc_yearset.py
@@ -1,11 +1,17 @@
-import random
-
 import numpy as np
 from climada.util import yearsets
 from scipy import sparse
 
 
-# PATCHING A BROKEN IMHO FUNCTION
+# THIS IS A QUICK FIX FOR A MORE COMPLEX PROBLEM
+# CLIMADA's yearsets currently generate years of data through a Poisson process. That is, the number of 'events' in a 
+# year is a random variable. This is great when our events are e.g. tropical cyclones and we're sampling from a 
+# stochastic set. It doesn't work when our events are e.g. wildfire or windstorm years. In this case we always want to 
+# sample exactly one 'event' per year. At some point we can add this functionality to CLIMADA as an additional method
+# within the yearsets code, but for now I'm making a workaround where if the Poisson process is asked to sample events 
+# with a frequency of 1/year it doesn't implement a Poisson process and instead returns exactly one event per year.
+# This isn't a valid fix because it's plausible that a user would eventually ask for a Poisson process with lamda = 1/yr 
+# and wouldn't be able to get that.
 def sample_from_poisson(n_sampled_years, lam, seed=None):
     """Sample the number of events for n_sampled_years
 
@@ -34,7 +40,6 @@ def sample_from_poisson(n_sampled_years, lam, seed=None):
             )
         ).astype('int')
     else:
-        # events_per_year = np.ones(len(n_sampled_years)) # this is the original line
         events_per_year = np.ones(n_sampled_years).astype('int')
 
     return events_per_year
@@ -43,18 +48,21 @@ def sample_from_poisson(n_sampled_years, lam, seed=None):
 yearsets.sample_from_poisson = sample_from_poisson
 
 
-def nccs_yearsets_simple(impact_list, n_sim_years, seed=1312):
+def nccs_yearsets_simple(impact_list, n_sim_years, seed=None):
     '''
     Generate yearsets from a list of impact objects.
     TODO: Make this more complex so that the year sampling is consistent across hazards
     i.e. when Cyclone X is selected in year Y for one yearset, it is selected in all cyclone yearsets
     '''
-    random.seed(seed)
-    return [yimp_from_imp_simple(imp, n_sim_years, seed=random.randint(1, 999999999)) for imp in impact_list] #TODO adjust code such that the subsector is the same each time
-    # return [yimp_from_imp_simple(imp, n_sim_years, seed=seed) for imp in impact_list] #TODO adjust code such that the subsector is the same each time
+    return [yimp_from_imp_simple(imp, n_sim_years, seed=seed) for imp in impact_list]
 
-def yimp_from_imp_simple(imp, n_sim_years, seed=1312):
-    lam = np.sum(imp.frequency)
+
+def yimp_from_imp_simple(imp, n_sim_years, seed=None):
+    if np.all(imp.frequency == 1):
+        lam = 1 
+    else:
+        lam = np.sum(imp.frequency)
+    
     yimp, samp_vec = yearsets.impact_yearset(
         imp,
         lam=lam,

--- a/pipeline/direct/test/create_test_impact.py
+++ b/pipeline/direct/test/create_test_impact.py
@@ -1,0 +1,48 @@
+import numpy as np
+from scipy import sparse
+import datetime as dt
+
+from climada.engine import Impact
+from climada.util.constants import DEF_CRS
+
+# Create simple impact objects for testing
+# Copied from climada.engine.test.test_impact
+
+def dummy_impact():
+    """Return an impact object for testing"""
+    return Impact(
+        event_id=np.arange(6) + 10,
+        event_name=[0, 1, "two", "three", 30, 31],
+        date=np.arange(6),
+        coord_exp=np.array([[1, 2], [1.5, 2.5]]),
+        crs=DEF_CRS,
+        eai_exp=np.array([7.2, 7.2]),
+        at_event=np.array([0, 2, 4, 6, 60, 62]),
+        frequency=np.array([1 / 6, 1 / 6, 1, 1, 1 / 30, 1 / 30]),
+        tot_value=7,
+        aai_agg=14.4,
+        unit="USD",
+        frequency_unit="1/month",
+        imp_mat=sparse.csr_matrix(
+            np.array([[0, 0], [1, 1], [2, 2], [3, 3], [30, 30], [31, 31]])
+        ),
+        haz_type="TC",
+    )
+
+def dummy_impact_yearly():
+    """Return an impact containing events in multiple years"""
+    imp = dummy_impact()
+
+    years = np.arange(2010,2010+len(imp.date))
+
+    # Edit the date and frequency
+    imp.date = np.array([dt.date(year,1,1).toordinal() for year in years])
+    imp.frequency_unit = "1/year"
+    imp.frequency = np.ones(len(years))/len(years)
+
+    # Calculate the correct expected annual impact
+    freq_mat = imp.frequency.reshape(len(imp.frequency), 1)
+    imp.eai_exp = imp.imp_mat.multiply(freq_mat).sum(axis=0).A1
+    imp.aai_agg = imp.eai_exp.sum()
+
+    return imp

--- a/pipeline/direct/test/test_calc_yearset.py
+++ b/pipeline/direct/test/test_calc_yearset.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 from copy import deepcopy
+from scipy import sparse
 
 from pipeline.direct.calc_yearset import nccs_yearsets_simple
 from pipeline.direct.test.create_test_impact import dummy_impact, dummy_impact_yearly
@@ -43,7 +44,10 @@ class TestYearsets(unittest.TestCase):
         """If we generate yearsets a second time with the same seed we get the same sampling"""
         yimp1 = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
         yimp2 = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
+        yimp3 = nccs_yearsets_simple([self.dummy_imp, self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
         np.testing.assert_allclose(yimp1[0].at_event, yimp2[0].at_event)
+        np.testing.assert_allclose(yimp1[0].at_event, yimp3[0].at_event)
+        np.testing.assert_allclose(yimp1[0].at_event, yimp3[1].at_event)
 
     def test_yearsets_sample_differently_without_a_seed(self):
         """...but if we don't set the seed we get a different sampling"""

--- a/pipeline/direct/test/test_calc_yearset.py
+++ b/pipeline/direct/test/test_calc_yearset.py
@@ -1,0 +1,56 @@
+import unittest
+import numpy as np
+from copy import deepcopy
+
+from pipeline.direct.calc_yearset import nccs_yearsets_simple
+from pipeline.direct.test.create_test_impact import dummy_impact, dummy_impact_yearly
+
+seed = 1312
+np.random.seed(seed)
+
+class TestYearsets(unittest.TestCase):
+
+    def setUp(self):
+        self.n_sim_years = 10
+        self.dummy_imp = dummy_impact()
+        self.dummy_imp_yearly = dummy_impact_yearly()
+        self.dummy_imp_yearly.frequency = np.ones_like(self.dummy_imp_yearly.frequency)
+
+    def test_yearset_with_poisson_process(self):
+        """Yearsets have their basic functionality working"""
+        yimp = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
+        np.testing.assert_array_almost_equal(self.dummy_imp.imp_mat.shape, (6, 2))
+        np.testing.assert_array_almost_equal(yimp[0].imp_mat.shape, (self.n_sim_years, 2))
+        # The max yearset impact is greater than any individual event (with this seed)
+        self.assertTrue(np.max(self.dummy_imp.at_event) < np.max(yimp[0].at_event))
+
+    def test_yearset_with_non_poisson_process(self):
+        """Our implementation of yearsets can handle sampling event sets where we always want exactly one event per year"""
+        yimp = nccs_yearsets_simple([self.dummy_imp_yearly], n_sim_years = self.n_sim_years, seed=seed)
+        np.testing.assert_array_almost_equal(self.dummy_imp_yearly.imp_mat.shape, (6, 2))
+        np.testing.assert_array_almost_equal(yimp[0].imp_mat.shape, (self.n_sim_years, 2))
+        # The max yearset impact is the same as the source impact (with this seed)
+        self.assertTrue(np.max(self.dummy_imp_yearly.at_event) == np.max(yimp[0].at_event))
+
+    def test_yearsets_sample_consistently_across_impacts(self):
+        """Yearsets use the same sampling method for each impact object they're given"""
+        yimp1 = nccs_yearsets_simple([self.dummy_imp, self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
+        yimp2 = nccs_yearsets_simple([self.dummy_imp_yearly, self.dummy_imp_yearly], n_sim_years = self.n_sim_years, seed=seed)
+        np.testing.assert_allclose(yimp1[0].at_event, yimp1[1].at_event)
+        np.testing.assert_allclose(yimp2[0].at_event, yimp2[1].at_event)
+
+    def test_yearsets_sample_consistently_when_repeated(self):
+        """If we generate yearsets a second time with the same seed we get the same sampling"""
+        yimp1 = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
+        yimp2 = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
+        np.testing.assert_allclose(yimp1[0].at_event, yimp2[0].at_event)
+
+    def test_yearsets_sample_differently_without_a_seed(self):
+        """...but if we don't set the seed we get a different sampling"""
+        yimp1 = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
+        yimp2 = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years)
+        self.assertFalse(np.all(yimp1[0].at_event == yimp2[0].at_event))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
If you sample the same impact set with the same seed, you'll always get the same events, no matter what point in the calculation chain it happens.

This was mainly solved by removing all seed setting and random number generation in our NCCS code, and just passing the seed to climada's `yearsets` methods.

Tests implemented to check this works.


Also I added a note (and possibly a bugfix) for the quickfix we use so that yearsets recognise the difference between sampling a radom number of random events for each year (the currently implemented functionality in CLIMADA, suitable for e.g. tropical cyclones) and sampling a fixed number of random events for each year (which is what we need for windstorms and wildfires, i.e. one year of data per year).