### PR TITLE
.fix(wildfire): updated default impact function of wildfire to 4km hazard resolution to scale down values

### DIFF
--- a/pipeline/direct/direct.py
+++ b/pipeline/direct/direct.py
@@ -247,7 +247,7 @@ def get_sector_impf_rf(country_iso3alpha):
 
 # for wildfire, not sure if it is working
 def get_sector_impf_wf():
-    impf = ImpfWildfire.from_default_FIRMS()
+    impf = ImpfWildfire.from_default_FIRMS(i_half=409.4) # adpated i_half according to hazard resolution of 4km: i_half=409.4
     impf.haz_type = 'WFseason'  # TODO there is a warning when running the code that the haz_type is set to WFsingle, but if I set it to WFsingle, the code does not work
     return impf
 

--- a/run_configurations/test_config.py
+++ b/run_configurations/test_config.py
@@ -8,26 +8,14 @@ CONFIG = {
     "n_sim_years": 100,
     "runs": [
         {
-            "hazard": "river_flood",
+            "hazard": "wildfire",
             "io_approach": ["leontief", "ghosh"],
             "sectors": ["manufacturing"],
-            "countries": ["Burundi"],
+            "countries": ['Italy'],
             "scenario_years": [
                 {"scenario": "None", "ref_year": "historical"},
-                # {"scenario": "rcp26", "ref_year": 2020},
-                # {"scenario": "rcp26", "ref_year": 2040},
-                {"scenario": "rcp26", "ref_year": 2060},
-                # {"scenario": "rcp26", "ref_year": 2080},
-                # {"scenario": "rcp60", "ref_year": 2020},
-                # {"scenario": "rcp60", "ref_year": 2040},
-                # {"scenario": "rcp60", "ref_year": 2060},
-                # {"scenario": "rcp60", "ref_year": 2080},
-                # {"scenario": "rcp85", "ref_year": 2020},
-                # {"scenario": "rcp85", "ref_year": 2040},
-                {"scenario": "rcp85", "ref_year": 2060},
-                # {"scenario": "rcp85", "ref_year": 2080},
             ]
-        },
+        }
     ]
 }
 


### PR DESCRIPTION
Updated code to use the "correct" impact function for wildfire.

Some detailed explanations:
- The Climada wildfire hazard which is used comes at a 4km resolution 
- According to the paper https://gmd.copernicus.org/articles/14/7175/2021/gmd-14-7175-2021.pdf, there are different impact functions depending on the hazard resolution
![image](https://github.com/ChrisFairless/nccs-supply-chain/assets/116871277/f5f67a15-50fa-4d34-aecc-ee657cf182ec)

- per default, we used the 1km resolution function by simply calling the default function: impf = ImpfWildfire.from_default_FIRMS(), which was this function:
![image](https://github.com/ChrisFairless/nccs-supply-chain/assets/116871277/2de9430d-0bea-4917-b48e-0f040fad6f48)

- In the updated version, we now specify i_half to be 409.4 which creates the sigmoid function to match with the WFseason 4km resolution. 
- The new function now looks like this and also leads to way smaller impacts (factor of 40,  tested with Italy)
![image](https://github.com/ChrisFairless/nccs-supply-chain/assets/116871277/d9e8a1ac-74f1-4f74-b6d2-f3f9dbbf4dd8)



--> The functions were calibrated with EM-DAT