### PR TITLE
Bugfix dashboard: deal with 'None' scenario when building for the first time

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -49,6 +49,7 @@ if not os.path.isfile("complete.csv"):
     # DS_INDIRECT_BASE["value"] = DS_INDIRECT_BASE["impact_aai"].copy() #TODO to be removed, old configurations,
     #  and used for best guesstimate run
     DS_INDIRECT_BASE['sector'] = [s[:50] for s in DS_INDIRECT_BASE['sector']]
+    DS_INDIRECT_BASE.scenario = ['None' if pd.isna(s) else s for s in DS_INDIRECT_BASE.scenario]
     DS_INDIRECT_BASE.to_csv("complete.csv")
 else:
     DS_INDIRECT_BASE = pd.read_csv("complete.csv")


### PR DESCRIPTION
If the complete.csv file isn't present for the dashboard to use and it's looking at scenarios called None, it converts them to nan instead of a string called None. This fixes that, analagously to how it's dealt with when complete.csv is present.