### PR TITLE
Bugfix agriculture region_ids

### DIFF
--- a/pipeline/direct/agriculture.py
+++ b/pipeline/direct/agriculture.py
@@ -69,6 +69,8 @@ def get_hazard(country,
             'year_range': year_range
         }
     )
+    if hasattr(hazard.centroids, 'gdf') and np.all(hazard.centroids.region_id == 1):   # if the region ids exist but are all 1 (happens in newer climada)
+        hazard.centroids.gdf.region_id = np.nan
     hazard.centroids.set_region_id()
     region_id = int(countries.get(alpha_3=country).numeric)
     return hazard.select(reg_id=region_id)


### PR DESCRIPTION
*This can wait until after the code and data freeze*

I was running into an issue where the CLIMADA API's downloaded relative crop yield hazard had all centroids with their `region_id` set to 1.

Since they were already set, we didn't recalculate them and then we couldn't filter to regions and therefore couldn't run any crop yield calculations.

Given that this didn't happen in previous runs of the model, I assume it's to do with the recent changes in the Centroids class to be a geodataframe. Not sure what though.

My quick and dirty workaround is to add a check: if the Centroids have a geodataframe, and if the geodataframe has `region_id`s all set to 1, then I set them to `nan` (meaning they'll be recalculated in the next line) and continue as planned.