### PR TITLE
Add economic_assets as a sector

### DIFF
--- a/pipeline/direct/direct.py
+++ b/pipeline/direct/direct.py
@@ -207,6 +207,7 @@ def get_sector_exposure(sector, country):
         exp = download_exposure_from_s3(country, file_short)
     
     if sector == 'economic_assets':
+        client = Client()
         exp = client.get_litpop(country)
 
     return exp

--- a/pipeline/direct/direct.py
+++ b/pipeline/direct/direct.py
@@ -205,6 +205,9 @@ def get_sector_exposure(sector, country):
     if sector == 'wood':
         file_short = f'manufacturing/manufacturing_sub_exposures/refinement_1/{sector}/country_split/{sector}_NOx_emissions_2011_above_100t_0.1deg_ISO3_values_Manfac_scaled'
         exp = download_exposure_from_s3(country, file_short)
+    
+    if sector == 'economic_assets':
+        exp = client.get_litpop(country)
 
     return exp
 
@@ -212,7 +215,7 @@ def get_sector_exposure(sector, country):
 def apply_sector_impf_set(hazard, sector, country_iso3alpha):
     haz_type = HAZ_TYPE_LOOKUP[hazard]
 
-    if not APPLY_BUSINESS_INTERRUPTION or sector == 'agriculture':
+    if not APPLY_BUSINESS_INTERRUPTION or sector in ['agriculture', 'economic_assets']:
         sector_bi = None
     else:
         sector_bi = sector


### PR DESCRIPTION
_Not urgent_

This new 'sector' uses vanilla LitPop as its exposure and doesn't apply any business interruption.

The results from the direct impact calculations will be useful for validation and calibration. The results from indirect impact calculations will fail, since this isn't a recognised MRIO sector.

i.e. this sector is designed to be called with functions within the pipeline.direct package and not part of a full supply chain run.

The implementation is very simple. We could make it more robust if we end up using it more often.