### PR TITLE
Add scripts to generate intermediate SLR impact data

### DIFF
--- a/resources/impacts/slr_intermediate/01_download_aqueduct_data.py
+++ b/resources/impacts/slr_intermediate/01_download_aqueduct_data.py
@@ -1,0 +1,99 @@
+import requests
+import os
+from pathlib import Path
+import pandas as pd
+
+aqueduct_url = 'https://wri-projects.s3.amazonaws.com/AqueductFloodTool/download/v2/'
+output_directory = Path('.', 'data', 'raw')
+
+rp_list = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1000]
+
+filename_base_list = [
+    'inuncoast',
+]
+scenario_list = [
+    'historical',
+    'rcp4p5',
+    'rcp8p5'
+]
+subsidence_list = [
+    'wtsub',
+]
+year_list = [
+    '2050',
+    '2080'
+]
+perc_list = [
+    None,
+    50
+]
+
+
+def download_file(filename, base_url, outdir):
+    print(filename)
+    out_path = Path(outdir, filename)
+    if os.path.exists(out_path):
+        print('File already exists at this location. Skipping: ' + str(out_path))
+        return out_path
+    response = requests.get(base_url + filename)
+    if response.ok:
+        with open(out_path, mode="wb") as f:
+            f.write(response.content)
+    else:
+        raise ValueError('Download failed')
+    return out_path
+
+
+download_list = []
+
+for filename_base in filename_base_list:
+    for scenario in scenario_list:
+        for subsidence in subsidence_list:
+            if scenario == 'historical':
+                scenario_year_list = ['hist']
+            else:
+                scenario_year_list = year_list
+            #TODO the same for percentiles, it'll simplify things
+            for year in scenario_year_list:
+                for rp in rp_list:
+                    rp_decimal = '5' if rp == 1 else '0'
+                    if scenario == 'historical':
+                        filename = f'{filename_base}_{scenario}_{subsidence}_{year}_rp{rp:04d}_{rp_decimal}.tif'
+                        out_path = download_file(filename, aqueduct_url, output_directory)
+                        d = dict(
+                            filename_base = filename_base,
+                            scenario = scenario,
+                            subsidence = subsidence,
+                            year = year,
+                            rp_int = rp,
+                            rp_decimal = rp_decimal,
+                            rp = float(rp) + float(rp_decimal) / 10,
+                            perc = None,
+                            url = aqueduct_url + filename,
+                            local_path = str(out_path)
+                        )
+                        download_list = download_list + [d]
+                    else:
+                        for perc in perc_list:
+                            if perc is None:
+                                filename = f'{filename_base}_{scenario}_{subsidence}_{year}_rp{rp:04d}_{rp_decimal}.tif'
+                            else:
+                                filename = f'{filename_base}_{scenario}_{subsidence}_{year}_rp{rp:04d}_{rp_decimal}_perc_{str(perc)}.tif'
+                            out_path = download_file(filename, aqueduct_url, output_directory)
+                            d = dict(
+                                filename_base = filename_base,
+                                scenario = scenario,
+                                subsidence = subsidence,
+                                year = year,
+                                rp_int = rp,
+                                rp_decimal = rp_decimal,
+                                rp = float(rp) + float(rp_decimal) / 10,
+                                perc = 95 if not perc else perc,
+                                url = aqueduct_url + filename,
+                                local_path = str(out_path)
+                            )
+                            download_list = download_list + [d]
+
+
+df = pd.DataFrame(download_list)
+df.to_csv(Path('.', 'data', 'aqueduct_download_metadata.csv'))

--- a/resources/impacts/slr_intermediate/02_calculate_bounding_boxes.py
+++ b/resources/impacts/slr_intermediate/02_calculate_bounding_boxes.py
@@ -1,0 +1,72 @@
+from climada.util.api_client import Client
+import climada.util.coordinates as u_coord
+import pandas as pd
+
+country_list = ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
+                'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh',
+                'Barbados',
+                'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia, Plurinational State of',
+                'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei Darussalam', 'Bulgaria',
+                'Burkina Faso',
+                'Burundi', 'Cabo Verde', 'Cambodia', 'Cameroon',
+                'Canada', 'Central African Republic', 'Chad', 'Chile', 'China', 'Colombia', 'Comoros',
+                'Congo',
+                'Congo, The Democratic Republic of the', 'Costa Rica', 'Croatia', "Côte d'Ivoire",
+                'Cuba', 'Cyprus', 'Czechia', 'Denmark', 'Djibouti', 'Dominica', 'Dominican Republic',
+                'Timor-Leste', 'Ecuador', 'Egypt', 'El Salvador', 'Equatorial Guinea', 'Eritrea',
+                'Estonia', 'Eswatini', 'Ethiopia', 'Fiji', 'Finland', 'France', 'Gabon', 'Gambia', 'Georgia',
+                'Germany', 'Ghana', 'Greece', 'Grenada', 'Guatemala', 'Guinea', 'Guinea-Bissau', 'Guyana',
+                'Haiti',
+                'Honduras', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran, Islamic Republic of', 'Iraq',
+                'Ireland', 'Israel', 'Italy', 'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati',
+                "Korea, Democratic People's Republic of",
+                'Korea, Republic of', 'Kuwait', 'Kyrgyzstan', "Lao People's Democratic Republic", 'Latvia',
+                'Lebanon',
+                'Lesotho', 'Liberia',
+                'Libya', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Madagascar', 'Malawi', 'Malaysia',
+                'Maldives',
+                'Mali', 'Malta', 'Marshall Islands', 'Mauritania', 'Mauritius',
+                'Mexico', 'Micronesia, Federated States of', 'Moldova, Republic of', 'Monaco', 'Mongolia',
+                'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands',
+                'New Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'North Macedonia', 'Norway', 'Oman',
+                'Pakistan',
+                'Palau', 'Panama', 'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines', 'Poland',
+                'Portugal',
+                'Qatar', 'Romania', 'Russian Federation', 'Rwanda', 'Saint Kitts and Nevis', 'Saint Lucia',
+                'Saint Vincent and the Grenadines', 'Samoa', 'San Marino', 'Sao Tome and Principe',
+                'Saudi Arabia',
+                'Senegal', 'Seychelles', 'Sierra Leone', 'Singapore', 'Slovakia', 'Slovenia',
+                'Solomon Islands', 'Somalia', 'South Africa', 'Spain', 'Sri Lanka', 'Sudan',
+                'Suriname', 'Sweden', 'Syrian Arab Republic', 'Taiwan, Province of China',
+                'Tajikistan', 'Tanzania, United Republic of', 'Thailand',
+                'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Tuvalu',
+                'Uganda',
+                'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay', 'Uzbekistan',
+                'Vanuatu', 'Venezuela, Bolivarian Republic of', 'Viet Nam', 'Yemen', 'Zambia',
+                'Zimbabwe']
+
+out_list = []
+client = Client()
+client.online = False
+
+for country in country_list:
+    print(country)
+    bbox = (180, 90, -180, -90)
+    try:
+        exp = client.get_litpop(country)
+        exp_bbox = u_coord.latlon_bounds(
+                    exp.gdf.latitude.values, exp.gdf.longitude.values, buffer=0.5)
+        bbox = (min(bbox[0], exp_bbox[0]), min(bbox[1], exp_bbox[1]), max(bbox[2], exp_bbox[2]), max(bbox[3], exp_bbox[3]))
+    except Exception as e:
+        print("That didn't work")
+        print(e)
+        continue
+    print(country)
+    print(bbox)
+    if bbox[0] >= bbox[2] or bbox[1] >= bbox[3]:
+        print("Couldn't figure out a bounding box")
+        continue
+    out_list = out_list + [{'country': country, 'lon_min': bbox[0], 'lat_min': bbox[1], 'lon_max': bbox[2], 'lat_max': bbox[3]}]
+
+pd.DataFrame(out_list).to_csv('./data/country_bounding_boxes.csv')
+

--- a/resources/impacts/slr_intermediate/03_calculate_exposure_metadata.py
+++ b/resources/impacts/slr_intermediate/03_calculate_exposure_metadata.py
@@ -1,0 +1,99 @@
+import sys
+sys.path.append('../../..')
+
+import pandas as pd
+import numpy as np
+import os
+from pathlib import Path
+import itertools
+from functools import reduce, partial
+import traceback
+import pycountry
+import climada.util.coordinates as u_coord
+import pathos as pa
+
+from pipeline.direct.direct import get_sector_exposure
+
+aqueduct_metadata_path = Path('.', 'data', 'aqueduct_download_metadata.csv')
+country_bounding_box_path = Path('.', 'data', 'country_bounding_boxes.csv')
+output_dir = Path('.', 'data')
+
+country_bounding_boxes = pd.read_csv(country_bounding_box_path)
+
+sector_list = ["agriculture", "forestry", "mining", "manufacturing", "service", "energy", "water", "waste",
+                        "basic_metals", "pharmaceutical", "food", "wood", "chemical", "rubber_and_plastic",
+                        "non_metallic_mineral", "refin_and_transform"]
+# sector_list = ["mining", "manufacturing"]
+# sector_list = ['service']
+
+# n_cpus = pa.helpers.cpu_count() - 1
+
+output_path = Path(output_dir, 'exposure_metadata.csv')
+assert(os.path.exists(output_dir))
+
+total_exposures = pd.DataFrame(columns=['sector', 'country', 'value', 'res', 'nrow', 'ncol', 'transform']).set_index(['sector', 'country'])
+
+
+# test_transform_values = [1, 2, 3, 4, 5, 6, 7, 8]
+# total_exposures.loc[('test', 'test')] = dict(
+#     value = 1000.0,
+#     res = 0.1,
+#     nrow = 10,
+#     ncol = 20,
+#     transform = test_transform_values
+# )
+
+for sector in sector_list:
+    print(f"Working on sector {sector}")
+    for _, crow in country_bounding_boxes.iterrows():
+        country = crow['country']
+        country_iso3num = pycountry.countries.get(name=crow['country']).numeric
+        print(f"Working on country {country}")
+        try:
+            sector_exp = get_sector_exposure(sector, crow['country'])
+        except Exception as e:
+            print("... couldn't get exposures from the API for some reason. Skipping.")
+            print("".join(traceback.format_exception(type(e), e, e.__traceback__)))
+            # total_exposures.loc[(sector, country), 'value'] = np.nan
+            continue
+
+        try:
+            if 'region_id' not in sector_exp.gdf.columns or \
+            (len(np.unique(sector_exp.gdf.region_id)) == 1 and sector_exp.gdf.region_id.iloc[0] == 0):
+                print("... assigning region ids")
+                sector_exp.set_region_id()
+            if len(np.unique(sector_exp.gdf.region_id)) > 1:
+                sector_exp.gdf = sector_exp.gdf[sector_exp.gdf['region_id'] == int(country_iso3num)]
+            if sector_exp.gdf.shape[0] == 0:
+                print(f"No region IDs for this country: {crow['country']}. Skipping")
+                # total_exposures.loc[(sector, country), 'value'] = np.nan
+                continue
+
+            res = np.abs(u_coord.get_resolution(
+                    sector_exp.gdf.latitude.values,
+                    sector_exp.gdf.longitude.values)
+                    ).min()
+            # Actually this is wrong, sorry, we added a buffer and also one sector bounds isn't the same as others. Phooey.
+            nrow, ncol, transform = u_coord.pts_to_raster_meta(
+                points_bounds=(crow['lon_min'], crow['lat_min'], crow['lon_max'], crow['lat_max']),
+                res = res
+            )
+            new_entry = dict(
+                value = sum(sector_exp.gdf['value']),
+                res = res,
+                nrow = nrow,
+                ncol = ncol,
+                transform = list(transform)
+            )
+            total_exposures.loc[(sector, country), :] = new_entry
+
+        except Exception as e:
+            print("... couldn't calculate sector totals for some reason. Skipping.")
+            print("".join(traceback.format_exception(type(e), e, e.__traceback__)))
+            total_exposures.loc[(sector, country), 'value'] = np.nan
+
+# total_exposures.to_csv(output_path)
+# total_exposures.drop(['test', 'test'])
+total_exposures.to_csv(output_path)
+
+

--- a/resources/impacts/slr_intermediate/04_calculate_slr_intermediate.py
+++ b/resources/impacts/slr_intermediate/04_calculate_slr_intermediate.py
@@ -1,0 +1,268 @@
+
+import sys
+sys.path.append('../../..')
+
+import pandas as pd
+import numpy as np
+import os
+from pathlib import Path
+from climada.hazard import Hazard, Centroids
+from climada.entity import Exposures
+import rioxarray as rxr
+import itertools
+import pycountry
+from functools import reduce, partial
+from climada.util.constants import DEF_CRS
+import climada.util.coordinates as u_coord
+import traceback
+import pathos as pa
+
+from pipeline.direct.direct import get_sector_exposure
+
+aqueduct_metadata_path = Path('.', 'data', 'aqueduct_download_metadata.csv')
+country_bounding_box_path = Path('.', 'data', 'country_bounding_boxes.csv')
+exposure_metadata_path = Path('.', 'data', 'exposure_metadata.csv')
+
+output_dir = Path('.', 'data', 'results')
+hazmap_dir = Path('.', 'data', 'intermediate')
+# aqueduct_metadata_path = Path('.', 'resources', 'impacts', 'slr_intermediate', 'data', 'aqueduct_download_metadata.csv')
+# country_bounding_box_path = Path('.', 'resources', 'impacts', 'slr_intermediate', 'data', 'country_bounding_boxes.csv')
+# output_dir = Path('.', 'resources', 'impacts', 'slr_intermediate', 'data', 'results')
+
+aqueduct_metadata = pd.read_csv(aqueduct_metadata_path)
+country_bounding_boxes = pd.read_csv(country_bounding_box_path)
+exposure_metadata = pd.read_csv(exposure_metadata_path)
+
+sector_list = ["agriculture", "forestry", "mining", "manufacturing", "service", "energy", "water", "waste",
+                "basic_metals", "pharmaceutical", "food", "wood", "chemical", "rubber_and_plastic",
+                "non_metallic_mineral", "refin_and_transform"]
+# sector_list = ["mining", "manufacturing"]
+# sector_list = ['manufacturing', 'pharmaceutical']
+
+n_cpus = pa.helpers.cpu_count() - 1
+# n_cpus = 1
+
+verbose = False
+
+country_subset = None
+rp_subset = None
+year_subset = None
+scenario_subset = None
+
+# country_subset = ['Cuba', 'Ireland']
+rp_subset = [100]
+year_subset = ['hist']
+scenario_subset = ['historical', 'rcp4p5', 'rcp8p5']
+
+assert(os.path.exists(output_dir))
+assert(os.path.exists(hazmap_dir))
+
+year_rank_map = {'hist': 0, '2020': 1, '2050': 2, '2080': 3}
+scenario_rank_map = {'historical': 0, 'rcp4p5': 1, 'rcp8p5': 2}
+aqueduct_metadata['year_rank'] = [year_rank_map[y] for y in aqueduct_metadata['year']]
+aqueduct_metadata['scenario_rank'] = [scenario_rank_map[s] for s in aqueduct_metadata['scenario']]
+aqueduct_metadata = aqueduct_metadata.sort_values(['rp', 'scenario_rank', 'year_rank'], ascending=False)
+assert(len(np.unique(aqueduct_metadata['subsidence'])) == 1)  # ranking doesn't include this yet
+
+aqueduct_metadata = aqueduct_metadata[aqueduct_metadata['perc'] != 50]  # not ready for this yet
+
+exposure_metadata = exposure_metadata[~pd.isna(exposure_metadata['res'])]
+exposure_metadata = exposure_metadata.merge(country_bounding_boxes, how='left', on=['country'])
+exposure_metadata = exposure_metadata.set_index(['country', 'sector'])
+
+# print(get_sector_exposure('refin_and_transform', 'Zimbabwe'))
+# raise ValueError()
+
+
+if rp_subset:
+    aqueduct_metadata = aqueduct_metadata[aqueduct_metadata['rp'].isin(rp_subset)]
+if year_subset:
+    aqueduct_metadata = aqueduct_metadata[aqueduct_metadata['year'].isin(year_subset)]
+if scenario_subset:
+    aqueduct_metadata = aqueduct_metadata[aqueduct_metadata['scenario'].isin(scenario_subset)]
+
+to_drop = []
+for (country, sector), _ in exposure_metadata.iterrows():
+    if country_subset and not country in country_subset:
+        to_drop = to_drop + [(country, sector)]
+        continue
+    if sector_list and not sector in sector_list:
+        to_drop = to_drop + [(country, sector)]
+        continue
+
+    future_outfiles = [
+        Path(output_dir, f"{row['scenario']}_{row['subsidence']}_{row['year']}_{row['rp']}_{sector}_{country.replace(' ', '')}.csv")
+        for _, row in aqueduct_metadata.iterrows()
+    ]
+    if np.all([os.path.exists(f) for f in future_outfiles]):
+        to_drop = to_drop + [(country, sector)]
+        continue
+
+exposure_metadata.drop(to_drop, inplace=True)
+
+def get_exposure_mappings(haz_df, transform):
+    if verbose:
+        print('transform')
+        print(transform)
+    # Partially stolen from climada.util.coordinates.match_grid_points
+    x = haz_df.index.get_level_values('lon')
+    y = haz_df.index.get_level_values('lat')
+    xres, _, xmin, _, yres, ymin = transform[:6]
+    xmin, ymin = xmin + 0.5 * xres, ymin + 0.5 * yres
+    x_i = np.round((x - xmin) / xres).astype(int)
+    y_i = np.round((y - ymin) / yres).astype(int)
+    lons = xmin + (x_i * xres)
+    lats = ymin + (y_i * yres)
+    lons = np.round(lons, 5)
+    lats = np.round(lats, 5)
+    return pd.DataFrame(dict(
+        haz_lat = y,
+        haz_lon = x,
+        exp_lat = lats,
+        exp_lon = lons
+    )).set_index(['haz_lat', 'haz_lon'])
+
+
+
+def process_flood_df(df, exp, country, sector, crow):
+    for _, row in df.iterrows():
+        print(f"Working on {row['local_path']}")
+        out_filename = f"{row['scenario']}_{row['subsidence']}_{row['year']}_{row['rp']}_{sector}_{country.replace(' ', '')}.csv"
+        out_path = Path(output_dir, out_filename)
+        if os.path.exists(out_path):
+            print('Output already exists: skipping')
+            continue
+        filepath = row['local_path']
+        slr = rxr.open_rasterio(filepath)
+        subset_lons = slr.x[np.multiply(slr.x >= crow['lon_min'], slr.x <= crow['lon_max'])]
+        subset_lats = slr.y[np.multiply(slr.y >= crow['lat_min'], slr.y <= crow['lat_max'])]
+        subset = slr.loc[1, subset_lats, subset_lons]
+
+        haz_df = subset.to_pandas()
+        haz_df = pd.melt(haz_df, var_name = 'x', value_name='depth', ignore_index=False)
+        haz_df = haz_df[haz_df['depth'] != slr._FillValue]
+        haz_df = haz_df[haz_df['depth'] > 0]
+        haz_df = haz_df.reset_index().rename(columns={'x': 'lon', 'y': 'lat'})
+        haz_df['lat'] = np.round(haz_df['lat'], 5)  # For index matching later
+        haz_df['lon'] = np.round(haz_df['lon'], 5)
+        haz_df.set_index(['lat', 'lon'], inplace=True)
+
+        # transform = crow['transform']
+        # transform = eval(transform) if isinstance(transform, str) else transform
+        res = np.abs(u_coord.get_resolution(exp.lat.values, exp.lon.values)).min()
+        _, _, transform = u_coord.pts_to_raster_meta(
+                points_bounds=(exp.lon.min(), exp.lat.min(), exp.lon.max(), exp.lat.max()),
+                res = res
+            )
+
+        exp = exp[exp['value'] > 0]
+        exp['lat'] = np.round(exp['lat'], 5)  # For index matching later
+        exp['lon'] = np.round(exp['lon'], 5)
+        mapping = get_exposure_mappings(haz_df, list(transform))
+
+        if verbose:
+            print('haz_df')
+            print(haz_df.sort_index())
+            print('mapping')
+            print(mapping.sort_index())
+
+        mapped = haz_df.merge(
+            mapping.rename_axis(index={'haz_lat': 'lat', 'haz_lon': 'lon'}), 
+            how='left', 
+            left_index=True, 
+            right_index=True
+        )
+
+        if verbose:
+            print("STAGE ONE")
+            print(mapped.sort_index())
+        mapped = mapped\
+            .reset_index()\
+            .drop(columns=['lat', 'lon'])\
+            .rename(columns={'exp_lat': 'lat', 'exp_lon': 'lon'})
+
+        if verbose:
+            print('exp_lon')
+            print(list(exp.sort_values(by='lon').lon))
+            print('mapped lon')
+            print(list(mapped.reset_index().sort_values(by='lon')['lon']))
+
+        mapped = mapped.merge(exp, how='inner', on=['lat', 'lon'])
+
+        if verbose:
+            print("STAGE TWO")
+            print(mapped.sort_values(by=['lat', 'lon']))
+            print('exp')
+            print(exp.sort_values(by=['lat', 'lon']))
+        if mapped.shape[0] == 0:
+            print("Didn't get any matches ... suspicious")
+
+        mapped = mapped.groupby(['lat', 'lon'])\
+            .agg('max')
+
+        if verbose:
+            print("STAGE THREE")
+            print(mapped.sort_values(by=['lat', 'lon']))
+
+        mapped.to_csv(out_path)
+
+
+
+def process_countrysector_df(df):
+    for (country, sector), crow in df[::-1].iterrows():
+        if country_subset and not country in country_subset:
+            continue
+        if sector_list and not sector in sector_list:
+            continue
+        print(f'Working on {country} - {sector}')
+
+        # future_outfiles = [
+        #     Path(output_dir, f"{row['scenario']}_{row['subsidence']}_{row['year']}_{row['rp']}_{sector}_{country.replace(' ', '')}.csv")
+        #     for _, row in aqueduct_metadata.iterrows()
+        # ]
+        # if np.all([os.path.exists(f) for f in future_outfiles]):
+        #     print("All outputs for this country-sector exist. Moving on.")
+        #     continue
+
+        try:
+            if verbose:
+                print("Getting exposure")
+            exp = get_sector_exposure(sector, country).gdf
+        except Exception as e:
+            print("Couldn't load exposure. Skipping")
+            print("".join(traceback.format_exception(type(e), e, e.__traceback__)))
+            continue
+
+        if verbose:
+            print("Validating exposure")
+        country_iso3num = pycountry.countries.get(name=country).numeric
+        if 'region_id' not in exp.columns or \
+            (len(np.unique(exp.region_id)) == 1 and exp.region_id.iloc[0] == 0):
+            raise ValueError("Need to assign region ids")
+            # sector_exp.set_region_id()
+        if len(np.unique(exp.region_id)) > 1:
+            exp = exp[exp['region_id'] == int(country_iso3num)]
+        if exp.shape[0] == 0:
+            print(f"No region IDs for this country: {country}. Skipping")
+            continue
+
+        exp = exp.rename(columns={'latitude': 'lat', 'longitude': 'lon'})
+        exp = exp[['lat', 'lon', 'value']]
+        if exp[exp['value'] > 0].shape[0] == 0:
+            print("No positive exposures here. Uh oh. Skipping")
+            continue
+
+        process_flood_df(aqueduct_metadata, exp=exp, country=country, sector=sector, crow=crow)
+        # chunk_size = int(np.ceil(aqueduct_metadata.shape[0] / n_cpus))
+        # chunked_df = [aqueduct_metadata[::-1].iloc[ix:(ix + chunk_size)] for ix in range(0, aqueduct_metadata.shape[0], chunk_size)]
+        # f_partial = partial(process_flood_df, exp=exp, country=country, sector=sector, crow=crow)
+
+        # with pa.multiprocessing.ProcessPool(n_cpus) as pool:
+        #     _ = pool.map(f_partial, chunked_df)
+
+chunk_size = int(np.ceil(exposure_metadata.shape[0] / n_cpus))
+chunked_df = [exposure_metadata.iloc[ix:(ix + chunk_size)] for ix in range(0, exposure_metadata.shape[0], chunk_size)]
+# f_partial = partial(process_countrysector_df)
+
+with pa.multiprocessing.ProcessPool(n_cpus) as pool:
+    _ = pool.map(process_countrysector_df, chunked_df)

--- a/resources/impacts/slr_intermediate/05_summarise_outputs.py
+++ b/resources/impacts/slr_intermediate/05_summarise_outputs.py
@@ -1,0 +1,129 @@
+import sys
+sys.path.append('../../..')
+
+import pandas as pd
+import numpy as np
+import os
+from pathlib import Path
+import itertools
+from functools import reduce, partial
+import traceback
+
+from pipeline.direct.direct import get_sector_exposure
+
+aqueduct_metadata_path = Path('.', 'data', 'aqueduct_download_metadata.csv')
+country_bounding_box_path = Path('.', 'data', 'country_bounding_boxes.csv')
+total_value_path = Path('.', 'data', 'total_exposure_values.csv')
+output_dir = Path('.', 'data', 'results')
+# aqueduct_metadata_path = Path('.', 'resources', 'impacts', 'slr_intermediate', 'data', 'aqueduct_download_metadata.csv')
+# country_bounding_box_path = Path('.', 'resources', 'impacts', 'slr_intermediate', 'data', 'country_bounding_boxes.csv')
+# output_dir = Path('.', 'resources', 'impacts', 'slr_intermediate', 'data', 'results')
+
+aqueduct_metadata = pd.read_csv(aqueduct_metadata_path)
+country_bounding_boxes = pd.read_csv(country_bounding_box_path)
+total_value_df = pd.read_csv(total_value_path).set_index(['sector', 'country'])
+flood_thresholds = [0, 0.5, 1, 1.5, 2, 3, 4, 5]
+
+sector_list = ["agriculture", "forestry", "mining", "manufacturing", "service", "energy", "water", "waste",
+                        "basic_metals", "pharmaceutical", "food", "wood", "chemical", "rubber_and_plastic",
+                        "non_metallic_mineral", "refin_and_transform"]
+# sector_list = ["mining", "manufacturing"]
+# sector_list = ['service']
+
+verbose = True
+include_missing = False
+
+assert(os.path.exists(output_dir))
+
+aqueduct_metadata = aqueduct_metadata[aqueduct_metadata['perc'] != 50]  # not ready for this yet
+
+
+def summarise_flooding(sector, crow, row, total_assets, output_dir, include_missing):
+    if not total_assets:
+        if include_missing:
+            return [
+                dict(
+                    scenario = row['scenario'],
+                    subsidence = row['subsidence'],
+                    year = row['year'],
+                    rp = 1.5 if row['rp'] == 1 else row['rp'],
+                    country = crow['country'],
+                    sector = sector,
+                    total_assets = np.nan,
+                    flood_depth_threshold = threshold,
+                    assets_affected = np.nan,
+                    pct_assets_affected = np.nan
+                ) for threshold in flood_thresholds
+            ]
+        else:
+            return []
+
+    if verbose:
+        print(f"Working on {row['local_path']}")
+
+    in_filename = f"{row['scenario']}_{row['subsidence']}_{row['year']}_{row['rp']}_{sector}_{crow['country'].replace(' ', '')}.csv"
+    in_path = Path(output_dir, in_filename)
+
+    if not os.path.exists(in_path):
+        if verbose:
+            print(f"... no data available for this combination. Skipping: {in_filename}")
+        if include_missing:
+            return [
+                    dict(
+                    scenario = row['scenario'],
+                    subsidence = row['subsidence'],
+                    year = row['year'],
+                    rp = 1.5 if row['rp'] == 1 else row['rp'],
+                    country = crow['country'],
+                    sector = sector,
+                    total_assets = total_assets,
+                    flood_depth_threshold = threshold,
+                    assets_affected = None,
+                    pct_assets_affected = None
+                ) for threshold in flood_thresholds
+            ]
+        else:
+            return []
+
+    exp_affected = pd.read_csv(in_path)
+
+    out_list = []
+    for threshold in flood_thresholds:
+        out = dict(
+            scenario = row['scenario'],
+            subsidence = row['subsidence'],
+            year = row['year'],
+            rp = 1.5 if row['rp'] == 1 else row['rp'],
+            country = crow['country'],
+            sector = sector,
+            total_assets = total_assets,
+            flood_depth_threshold = threshold,
+            assets_affected = sum(exp_affected[exp_affected['depth'] >= threshold]['value'])
+        )
+        out['pct_assets_affected'] = 0 if out['assets_affected'] == 0 else out['assets_affected'] / out['total_assets']
+        out_list = out_list + [out]
+    return out_list
+    
+
+combined_out = []
+combined_out_filename = "risk_stats_ALL.csv"
+combined_out_path = Path(output_dir, combined_out_filename)
+
+for sector in sector_list:
+    print(f"Working on sector {sector}")
+    for _, crow in country_bounding_boxes.iterrows():
+        print(f"Working on country {crow['country']}")
+        # combined_out = []
+        # combined_out_filename = f"risk_stats_{sector}_{crow['country']}.csv"
+        # combined_out_path = Path(output_dir, combined_out_filename)
+        # if os.path.exists(combined_out_path):
+        #     print("... output already exists. Skipping.")
+        #     continue
+
+        total_assets = total_value_df.loc[(sector, crow['country']), 'value']
+
+        for _, row in aqueduct_metadata.iterrows():
+            combined_out = combined_out + summarise_flooding(sector, crow, row, total_assets, output_dir, include_missing)
+
+combined_out = pd.DataFrame(combined_out)
+combined_out.to_csv(combined_out_path)

--- a/resources/impacts/slr_intermediate/validation_create_haz_exp_mappings.py
+++ b/resources/impacts/slr_intermediate/validation_create_haz_exp_mappings.py
@@ -1,0 +1,147 @@
+# This script is unused in the final modelling chain
+# However its method for mapping between the Exposure datasets and the SLR data is more accurate than the (much faster) 
+# method used in the final script. I recommend using it as a way to validate that all grid cells are successfully 
+# matched, especially in larger countries where small errors in grid spacing definitions might add up to large errors
+# across large distances
+
+import sys
+sys.path.append('../../..')
+
+import pandas as pd
+import numpy as np
+import os
+from pathlib import Path
+from climada.hazard import Hazard, Centroids
+from climada.entity import Exposures
+import rioxarray as rxr
+import itertools
+import pycountry
+from functools import reduce, partial
+from climada.util.constants import DEF_CRS
+import climada.util.coordinates as u_coord
+import traceback
+import pathos as pa
+
+from pipeline.direct.direct import get_sector_exposure
+
+aqueduct_metadata_path = Path('.', 'data', 'aqueduct_download_metadata.csv')
+country_bounding_box_path = Path('.', 'data', 'country_bounding_boxes.csv')
+exposure_metadata_path = Path('.', 'data', 'exposure_metadata.csv')
+
+mapping_metadata_outpath = Path('.', 'data', 'hazard_exposure_mapping_metadata.csv')
+
+output_dir = Path('.', 'data', 'deleteme_results')
+hazmap_dir = Path('.', 'data', 'deleteme_intermediate')
+# aqueduct_metadata_path = Path('.', 'resources', 'impacts', 'slr_intermediate', 'data', 'aqueduct_download_metadata.csv')
+# country_bounding_box_path = Path('.', 'resources', 'impacts', 'slr_intermediate', 'data', 'country_bounding_boxes.csv')
+# output_dir = Path('.', 'resources', 'impacts', 'slr_intermediate', 'data', 'results')
+
+aqueduct_metadata = pd.read_csv(aqueduct_metadata_path)
+country_bounding_boxes = pd.read_csv(country_bounding_box_path)
+exposure_metadata = pd.read_csv(exposure_metadata_path)
+
+sector_list = ["agriculture", "forestry", "mining", "manufacturing", "service", "energy", "water", "waste",
+                "basic_metals", "pharmaceutical", "food", "wood", "chemical", "rubber_and_plastic",
+                "non_metallic_mineral", "refin_and_transform"]
+# sector_list = ["mining", "manufacturing"]
+# sector_list = ['manufacturing', 'pharmaceutical']
+
+n_cpus = pa.helpers.cpu_count() - 1
+# n_cpus = 4
+
+assert(os.path.exists(output_dir))
+assert(os.path.exists(hazmap_dir))
+
+year_rank_map = {'hist': 0, '2020': 1, '2050': 2, '2080': 3}
+scenario_rank_map = {'historical': 0, 'rcp4p5': 1, 'rcp8p5': 2}
+aqueduct_metadata['year_rank'] = [year_rank_map[y] for y in aqueduct_metadata['year']]
+aqueduct_metadata['scenario_rank'] = [scenario_rank_map[s] for s in aqueduct_metadata['scenario']]
+aqueduct_metadata = aqueduct_metadata.sort_values(['rp', 'scenario_rank', 'year_rank'], ascending=False)
+assert(len(np.unique(aqueduct_metadata['subsidence'])) == 1)  # ranking doesn't include this yet
+
+aqueduct_metadata = aqueduct_metadata[aqueduct_metadata['perc'] != 50]  # not ready for this yet
+
+exposure_metadata = exposure_metadata[~pd.isna(exposure_metadata['res'])]
+exposure_metadata = exposure_metadata.sort_values(['country', 'sector']).set_index(['country', 'sector'])
+exposure_metadata['res'] = np.round(exposure_metadata['res'], 5)
+
+mapping_df = pd.DataFrame(columns=['country', 'sector', 'mapping_filename']).set_index(['country', 'sector'])
+
+
+max_slr_metadata = aqueduct_metadata.iloc[0]
+slr = rxr.open_rasterio(max_slr_metadata['local_path'])
+
+def combine_transforms(transform_list):
+    transform_list = [eval(t) if isinstance(t, str) else t for t in transform_list]
+    xres = transform_list[0][0]
+    yres = transform_list[0][4]
+    assert(np.min(np.abs([t[0] - xres for t in transform_list])) < 0.0001)
+    assert(np.min(np.abs([t[4] - yres for t in transform_list])) < 0.0001)
+    xmin = np.min([t[2] for t in transform_list])
+    ymin = np.min([t[5] for t in transform_list])
+    out = transform_list[0]
+    out[2] = xmin
+    out[5] = ymin
+    return out
+
+def get_exposure_mappings(haz_df, transform):
+    # Partially stolen from climada.util.coordinates.match_grid_points
+    x = haz_df.index.get_level_values('lon')
+    y = haz_df.index.get_level_values('lat')
+    xres, _, xmin, _, yres, ymin = transform[:6]
+    xmin, ymin = xmin + 0.5 * xres, ymin + 0.5 * yres
+    x_i = np.round((x - xmin) / xres).astype(int)
+    y_i = np.round((y - ymin) / yres).astype(int)
+    lons = xmin + (x_i * xres)
+    lats = ymin + (y_i * yres)
+    return pd.DataFrame(dict(
+        haz_lat = y,
+        haz_lon = x,
+        exp_lat = lats,
+        exp_lon = lons
+    ))
+
+
+for _, crow in country_bounding_boxes.iterrows():
+    country = crow['country']
+    print(f"Working on country {country}")
+    country_iso3num = pycountry.countries.get(name=crow['country']).numeric
+
+    country_exposures_df = exposure_metadata.loc[country]
+    if country_exposures_df.shape[0] == 0:
+        print("... no exposures for this country. Skipping.")
+        continue
+
+    subset_lons = slr.x[np.multiply(slr.x >= crow['lon_min'], slr.x <= crow['lon_max'])]
+    subset_lats = slr.y[np.multiply(slr.y >= crow['lat_min'], slr.y <= crow['lat_max'])]
+    subset = slr.loc[1, subset_lats, subset_lons]
+    haz_df = subset.to_pandas()
+    haz_df = pd.melt(haz_df, var_name = 'x', value_name='depth', ignore_index=False)
+    haz_df = haz_df[haz_df['depth'] != slr._FillValue]
+    haz_df = haz_df[haz_df['depth'] > 0]
+    haz_df = haz_df.reset_index().rename(columns={'x': 'lon', 'y': 'lat'})
+    haz_df['lat'] = np.round(haz_df['lat'], 6)  # For index matching later
+    haz_df['lon'] = np.round(haz_df['lon'], 6)
+    haz_df.set_index(['lat', 'lon'], inplace=True)
+
+    if haz_df.shape[0] == 0:
+        print(f'... no hazard near to exposures. No mapping for {country}')
+        continue
+
+    for res in np.unique(country_exposures_df['res']):
+        print(f'... finding mappings for resolution {res}')
+        res_exposures_df = country_exposures_df[country_exposures_df['res'] == res]
+        this_sectors = list(res_exposures_df.index.get_level_values('sector'))
+        print(f'   ... sectors: {this_sectors}')
+        transform = combine_transforms(res_exposures_df['transform'])
+        mapping = get_exposure_mappings(haz_df, transform)
+        mapping_filename = f'hazmap_{country}_{this_sectors[0]}.csv'
+        mapping.to_csv(Path(hazmap_dir, mapping_filename))
+        for i_sector in this_sectors:
+            mapping_df.loc[(i_sector, country), 'mapping_filename'] = mapping_filename
+
+mapping_df.to_csv(mapping_metadata_outpath)
+
+
+
+


### PR DESCRIPTION
Without a probabilistic sea level rise dataset we're producing an intermediate product that overlays the WRI Aqueduct coastal flooding risk return period maps for different scenarios and return periods with the different exposures used in our analyses.

The methodology assigns each grid cell in the SLR risk map to the exposure grid cell that it's within (since the Exposures are lower resolution than the SLR map). Then it takes the maximum flood depth for each exposure as its result.

These exposure-flood depth mappings are written out, and summary statistics of affected percentages by country are created.

The method is slow and computationally expensive. There's definitely a smarter way to do this by converting the CLIMADA exposures to rasters, but I leave that for a smarter person to do.

This add scripts to resources/impacts/slr_intermediate:
- 01_download_aqueduct_data.py: Downloads the raw data from the WRI site. Exposure data is assumed to exist and is accessed through the CLIMADA Data API or (currently) the team's S3 bucket. Writes metadata for the files to data/aqueduct_download_metadata.csv
- 02_calculate_bounding_boxes.py As preparation, calculates a rough bounding box for each country that we'll be working with and stores it in a CSV. (Could actually be removed since the next script also does something similar, but the chain was working so I haven't done this). Writes to data/country_bounding_boxes.csv
- 03_calculate_exposure_metadata.py As preparation, calculates summary stats for each sector-exposure combination, including total economic value and the inferred raster metadata for its underlying grid. Writes to data/exposure_metadata.csv
- 04_calculate_slr_intermediate.py The main calculation. Loops through each sector-exposure combination of exposures and through each sea level rise scenario-year-return period hazard map to calculate the maximum flood depth at each exposure point and writes results to data/results/*
- 05_summarise_outputs.py Summarises the above stats to give, for each combination of country, sector, scenario, return period, future year and flood depth, the total value of assets affected, expressed as a dollar value and a % of total assets