### PR TITLE
BIG REFACTOR

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -8,7 +8,7 @@ from pipeline.indirect.indirect import dump_direct_to_csv, dump_supchain_to_csv,
 from utils import folder_naming
 
 
-def calc_supply_chain_impacts(
+def run_pipeline(
         country_list,
         hazard_list,
         sector_list,
@@ -97,42 +97,7 @@ def calc_supply_chain_impacts(
     print("Don't forget to update the current run title within the dashboard.py script: RUN_TITLE")
 
 
-def run_pipeline(country_list,
-                 hazard,
-                 sector_list,
-                 scenario,
-                 ref_year,
-                 n_sim_years,
-                 io_approach,
-                 direct_output_dir,
-                 indirect_output_dir,
-                 business_interruption=True,
-                 calibrated=True):
-    for country in country_list:
-        try:
-            calc_supply_chain_impacts(
-                [country],  # replace by country_list if whole list should be calculated at once
-                [hazard],
-                sector_list,
-                scenario,
-                ref_year,
-                n_sim_years,
-                io_approach,
-                direct_output_dir=direct_output_dir,
-                indirect_output_dir=indirect_output_dir,
-                business_interruption=business_interruption,
-                calibrated=calibrated
-            )
-        except Exception as e:
-            print(f"Could not calculate country {country} {sector_list}:")
-            print("".join(traceback.format_exception(type(e), e, e.__traceback__)))
-            print(e)
-
-    print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")
-
-
 def run_pipeline_from_config(config):
-
     direct_output_dir = folder_naming.get_direct_output_dir(config['run_title'])
     indirect_output_dir = folder_naming.get_indirect_output_dir(config['run_title'])
 

--- a/analysis.py
+++ b/analysis.py
@@ -233,9 +233,14 @@ def run_pipeline_from_config(
 
             try:
                 print(f"Calculating indirect impacts for {row['country']} {row['sector']}...")
+                imp = Impact.from_hdf5(row['yearset_path'])
+                if not imp.at_event.any():
+                    # TODO return an object with zero losses so that there's data
+                    print("No non-zero impacts. Skipping")
+                    continue
                 supchain = supply_chain_climada(
                     get_sector_exposure(sector=row['sector'], country=row['country']),
-                    Impact.from_hdf5(row['yearset_path']),
+                    imp,
                     impacted_sector=row['sector'],
                     io_approach=io_a
                 )

--- a/analysis.py
+++ b/analysis.py
@@ -22,8 +22,8 @@ from utils.s3client import upload_to_s3_bucket, file_exists_on_s3_bucket, downlo
 
 DO_PARALLEL = True
 
-DO_DIRECT = False       # Calculate any direct impacts that are missing based on the config
-DO_YEARSETS = False     # Calculate any direct impact yearsets that are missing based on the config
+DO_DIRECT = True       # Calculate any direct impacts that are missing based on the config
+DO_YEARSETS = True     # Calculate any direct impact yearsets that are missing based on the config
 DO_MULTIHAZARD = False  # Also combine hazards in each calculation year to shock the supply chain
 DO_INDIRECT = True      # Calculate any indirect impacts that are missing based on the config
 

--- a/analysis.py
+++ b/analysis.py
@@ -1,47 +1,179 @@
-import os.path
+import os
 import traceback
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from copy import deepcopy
+import json
+from datetime import datetime
+import typing
+import pathos as pa
+from functools import partial
 
-from pipeline.direct.calc_yearset import nccs_yearsets_simple
-# from utils.s3client import download_from_s3_bucket, upload_to_s3_bucket
-from pipeline.direct.direct import get_sector_exposure, nccs_direct_impacts_list_simple
+from climada.engine import Impact
+
+from pipeline.direct.direct import get_sector_exposure, nccs_direct_impacts_simple
+from pipeline.direct.calc_yearset import yearset_from_imp, combine_yearsets
 from pipeline.indirect.indirect import dump_direct_to_csv, dump_supchain_to_csv, supply_chain_climada
 from utils import folder_naming
+from utils.s3client import upload_to_s3_bucket, file_exists_on_s3_bucket, download_from_s3_bucket
 
 
-def run_pipeline(
-        country_list,
-        hazard_list,
-        sector_list,
-        scenario,
-        ref_year,
-        n_sim_years,
-        io_approach,
-        save_by_country=False,
-        save_by_hazard=False,
-        save_by_sector=False,
-        seed=1312,
-        indirect_output_dir="results/indirect",
-        direct_output_dir="results/direct",
-        business_interruption=True,
-        calibrated=True
-):
+DO_PARALLEL = True
+ncpus = pa.helpers.cpu_count() - 1
+ncpus = 3
+
+def run_pipeline_from_config(
+        config: dict,
+        direct_output_dir: typing.Union[str, os.PathLike] = None,
+        indirect_output_dir: typing.Union[str, os.PathLike] = None,
+        use_s3: bool = False,
+        force_recalculation: bool = False
+        ):
+    """Run the full model NCCS supply chain from a config dictionary.
+    
+    The method uses the input config object to create a dataframe with one 
+    row for each analysis required for the run, based on the requested 
+    scenarios, sectors, countries and hazards. It creates an impact object 
+    for each analysis, a yearset based on these impacts, and runs the 
+    supply chain model for each yearset, and writes outputs as it goes.
+
+    Parameters
+    ----------
+    config : dict
+        A dictionary describing the full model run configuration. See the 
+        examples in run_configurations/ for how these are constructed
+    direct_output_dir : str or os.PathLike
+        Location to store direct impact calculation results 
+        (both impact objects and the yearsets created from them). Generated 
+        automatically from the config run name if not provided
+    indirect_output_dir : str or os.PathLike
+        location to store indirect impact calculation results. 
+        Generated automatically from the config run name if not provided
+    use_s3 : bool
+        Look in the S3 bucket for existing results, and save files to the 
+        bucket
+    force_recalculation: bool
+        If outputs exist for this run name, recalculate them and overwrite.
+    """
+
+    if not direct_output_dir:
+        direct_output_dir = folder_naming.get_direct_output_dir(config['run_title'])
+    
+    if not indirect_output_dir:
+        indirect_output_dir = folder_naming.get_indirect_output_dir(config['run_title'])
+
+    os.makedirs(direct_output_dir, exist_ok=True)
+    os.makedirs(indirect_output_dir, exist_ok=True)
+
+    config['time_run'] = str(datetime.now())
+    with open(Path(indirect_output_dir, 'config.json'), 'w') as f:
+        json.dump(config, f)
+    
+    print(f"Direct output will be saved to {direct_output_dir}")
+    
     ### --------------------------------- ###
     ### CALCULATE DIRECT ECONOMIC IMPACTS ###
     ### --------------------------------- ###
 
-    # Generate a data frame with metadata, exposure objects and impact objects 
-    # for each combination of input factors.
-    analysis_df = nccs_direct_impacts_list_simple(hazard_list, sector_list, country_list, scenario, ref_year, business_interruption, calibrated)
+    ### Read the config to create a list of simulations
+    analysis_df = config_to_dataframe(config, direct_output_dir, indirect_output_dir)
+
+    # Generate a dataframe with metadata, and filepaths for each analysis
+    # definte in the input config.
+    direct_output_dir_impact = Path(direct_output_dir, "impact_raw")
+    direct_output_dir_yearsets = Path(direct_output_dir, "yearsets")
+    os.makedirs(direct_output_dir_impact, exist_ok=True)
+    os.makedirs(direct_output_dir_yearsets, exist_ok=True)
+
+    analysis_df['_direct_impact_already_exists'] = [exists_impact_file(p, use_s3) for p in analysis_df['direct_impact_path']]
+    analysis_df['_direct_impact_calculate'] = True if force_recalculation else ~analysis_df['_direct_impact_already_exists']
+
+    def calculate_direct_impacts_from_df(df, use_s3):
+        # TODO subset the df before this check is made. Risk of some parallel processes having no work to do
+        for _, calc in df.iterrows():            
+            if not calc['_direct_impact_calculate']: 
+                continue
+
+            try:
+                imp = nccs_direct_impacts_simple(
+                    haz_type=calc['hazard'],
+                    sector=calc['sector'],
+                    country=calc['country'],
+                    scenario=calc['scenario'],
+                    ref_year=calc['ref_year'],
+                    business_interruption=config['business_interruption'],
+                    calibrated=config['calibrated']
+                )
+                write_impact_to_file(imp, calc['direct_impact_path'], use_s3)
+            except Exception as e:
+                print(f"This didn't work: {e}")
+    
+    if DO_PARALLEL:
+        chunk_size = int(np.ceil(analysis_df.shape[0] / ncpus))
+        df_chunked = [analysis_df[i:i + chunk_size] for i in range(0, analysis_df.shape[0], chunk_size)]
+        calc_partial = partial(calculate_direct_impacts_from_df, use_s3=use_s3)
+        with pa.multiprocessing.ProcessPool(ncpus) as pool:
+            pool.map(calc_partial, df_chunked)    
+    else:
+        calculate_direct_impacts_from_df(analysis_df, use_s3)
+
+    analysis_df['_direct_impact_exists'] = [exists_impact_file(p, use_s3) for p in analysis_df['direct_impact_path']]
+    analysis_df.to_csv(Path(direct_output_dir, 'calculations_report.csv'))
+
 
     ### ------------------- ###
     ### SAMPLE IMPACT YEARS ###
     ### ------------------- ###
 
-    # Sample impact objects to create a yearset for each row of the data frame
-    analysis_df['impact_yearset'] = nccs_yearsets_simple(
-        analysis_df['impact_eventset'],
-        n_sim_years, seed=seed
-    )
+    # Create a yearset for each row of the analysis dataframe
+    # This gives us an impact object where each event is a fictional year of events   
+    print("Generating yearsets")
+    yearset_output_dir = Path(direct_output_dir, "yearsets")
+    os.makedirs(yearset_output_dir, exist_ok=True)
+
+    analysis_df['_yearset_already_exists'] = [exists_impact_file(p, use_s3) for p in analysis_df['yearset_path']]
+    analysis_df['_yearset_calculate'] = (True if force_recalculation else ~analysis_df['_yearset_already_exists']) * analysis_df['_direct_impact_exists']
+
+    def calculate_yearsets_from_df(df, config, use_s3):
+        for _, calc in df.iterrows():
+            if not calc['_yearset_calculate']: 
+                continue
+            try:
+                imp_yearset = create_single_yearset(
+                    calc,
+                    n_sim_years=config['n_sim_years'],
+                    seed=config['seed'],
+                )
+                write_impact_to_file(imp_yearset, calc['yearset_path'], use_s3)
+            except Exception as e:
+                print(f"This didn't work: {e}") 
+    
+    if DO_PARALLEL:
+        chunk_size = int(np.ceil(analysis_df.shape[0] / ncpus))
+        df_chunked = [analysis_df[i:i + chunk_size] for i in range(0, analysis_df.shape[0], chunk_size)]
+        calc_partial = partial(calculate_yearsets_from_df, config=config, use_s3=use_s3)
+        with pa.multiprocessing.ProcessPool(ncpus) as pool:
+            pool.map(calc_partial, df_chunked)    
+    else:
+        calculate_yearsets_from_df(analysis_df, config, use_s3)
+
+    analysis_df['_yearset_exists'] = [exists_impact_file(p, use_s3) for p in analysis_df['yearset_path']]
+    analysis_df.to_csv(Path(direct_output_dir, 'calculations_report.csv'))
+
+
+    # Next: combine yearsets by hazard to create multihazard yearsets
+
+    # We get a bit stricter: each run in the config file should have the same number of scenarios
+    _ = _check_config_valid_for_indirect_aggregations(config)
+    grouping_cols = ['i_scenario', 'sector', 'country']
+
+    df_aggregated_yearsets = analysis_df \
+    .groupby(grouping_cols)[grouping_cols + ['hazard', 'scenario', 'ref_year', 'yearset_path']] \
+    .apply(df_create_combined_hazard_yearsets) \
+    .reset_index()
+
+    analysis_df = pd.concat([analysis_df, df_aggregated_yearsets]).reset_index()  # That's right! I don't know how to use reset_index!
 
     ### ----------------------------------- ###
     ### CALCULATE INDIRECT ECONOMIC IMPACTS ###
@@ -49,78 +181,309 @@ def run_pipeline(
 
     # Generate supply chain impacts from the yearsets
     # Create a folder to output the data
-    os.makedirs("results", exist_ok=True)
+    # indirect_output_dir = Path(indirect_output_dir, "results")
+    os.makedirs(indirect_output_dir, exist_ok=True)
+    
+    analysis_df['_indirect_exists'] = False  # TODO: update this to check for existing output
+    analysis_df['_indirect_calculate'] = analysis_df['_yearset_exists']
 
-    # Run the Supply Chain for each country and sector and output the data needed to csv
-    for io_a in io_approach:
-        for _, row in analysis_df.iterrows():
+    def calculate_indirect_impacts_from_df(df, io_a, config, direct_output_dir):
+        # TODO consider some sort of grouping so that we don't need to load sector exposures each time...
+        # No need to parallelise this: it already seems to max out the CPUs
+        for i, row in df.iterrows():
+            print("SUPPLY CHAIN ROW")
+            print(row.to_dict())
             try:
                 print(f"Calculating indirect impacts for {row['country']} {row['sector']}...")
                 supchain = supply_chain_climada(
                     get_sector_exposure(sector=row['sector'], country=row['country']),
-                    row['impact_yearset'],
+                    Impact.from_hdf5(row['yearset_path']),
                     impacted_sector=row['sector'],
                     io_approach=io_a
                 )
                 # save direct impacts to a csv
+                # TODO: also save to S3
                 dump_direct_to_csv(
                     supchain=supchain,
-                    haz_type=row['haz_type'],
+                    haz_type=row['hazard'],
                     sector=row['sector'],
-                    scenario=scenario,
-                    ref_year=ref_year,
+                    scenario=row['scenario'],
+                    ref_year=row['ref_year'],
                     country=row['country'],
-                    n_sim=n_sim_years,
+                    n_sim=config['n_sim_years'],
                     return_period=100,
                     output_dir=direct_output_dir
                 )
                 # save indirect impacts to a csv
+                # TODO: also save to S3
                 dump_supchain_to_csv(
                     supchain=supchain,
-                    haz_type=row['haz_type'],
+                    haz_type=row['hazard'],
                     sector=row['sector'],
-                    scenario=scenario,
-                    ref_year=ref_year,
+                    scenario=row['scenario'],
+                    ref_year=row['ref_year'],
                     country=row['country'],
-                    n_sim=n_sim_years,
+                    n_sim=config['n_sim_years'],
                     return_period=100,
                     io_approach=io_a,
                     output_dir=indirect_output_dir
                 )
+                df.loc[i, '_indirect_exists'] = True
 
-            except ValueError as e:
+            except Exception as e:
                 print(f"Error calculating indirect impacts for {row['country']} {row['sector']}:")
                 print("".join(traceback.format_exception(type(e), e, e.__traceback__)))
                 print(e)
+
+    # Run the Supply Chain for each country and sector and output the data needed to csv
+    for io_a in config['io_approach']:
+        if False or DO_PARALLEL:  # Actually it looks llike a serial calculation is just as efficient
+            chunk_size = int(np.ceil(analysis_df.shape[0] / ncpus))
+            df_chunked = [analysis_df[i:i + chunk_size] for i in range(0, analysis_df.shape[0], chunk_size)]
+            calc_partial = partial(calculate_indirect_impacts_from_df, io_a=io_a, config=config, direct_output_dir=direct_output_dir)
+            with pa.multiprocessing.ProcessPool(ncpus) as pool:
+                pool.map(calc_partial, df_chunked)  
+        else:
+            calculate_indirect_impacts_from_df(analysis_df, io_a, config, direct_output_dir)
+
+    analysis_df.to_csv(Path(indirect_output_dir, 'calculations_report.csv'))
 
     print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")
     print("Don't forget to update the current run title within the dashboard.py script: RUN_TITLE")
 
 
-def run_pipeline_from_config(config):
-    direct_output_dir = folder_naming.get_direct_output_dir(config['run_title'])
-    indirect_output_dir = folder_naming.get_indirect_output_dir(config['run_title'])
+def config_to_dataframe(
+        config: dict,
+        direct_output_dir: typing.Union[str, os.PathLike],
+        indirect_output_dir: typing.Union[str, os.PathLike]):
+    """Convert a run config to a dataframe of required model runs. 
+    Note: these don't include model runs that combine hazards, sectors and 
+    countries, which are created after this first set is run.
 
-    os.makedirs(direct_output_dir, exist_ok=True)
-    os.makedirs(indirect_output_dir, exist_ok=True)
-    print(f"Direct output will be saved to {direct_output_dir}")
+    Parameters
+    ----------
+    config : dict
+        A config object. See run_configurations/ for the format
+    direct_output_dir : str or os.PathLike
+        Location to save direct impact modelling outputs
+    indirect_output_dir : str or os.PathLike
+        Location to save supply chain impact modelling outputs
+        
+    Returns
+    -------
+    pandas.DataFrame
+        A dataframe with one row for each simulation that will be run in the 
+        supply chain modelling, and the parameters required to run the 
+        simulations.
+    """
+    df = pd.DataFrame([
+        {
+                'hazard': run['hazard'],
+                'sector': sector,
+                'country': country,
+                'scenario': scenario['scenario'],
+                'i_scenario': i,
+                'ref_year': scenario['ref_year'],
+        }
+        for run in config['runs']
+        for i, scenario in enumerate(run['scenario_years'])
+        for country in run['countries']
+        for sector in run['sectors']
+    ])
+    for i, row in df.iterrows():
+        direct_impact_filename = folder_naming.get_direct_namestring(
+            prefix="impact_raw",
+            extension="hdf5",
+            haz_type=row['hazard'],
+            sector=row['sector'],
+            country_iso3alpha=row['country'],
+            scenario=row['scenario'],
+            ref_year=row['ref_year']
+        )
+        direct_impact_path = Path(direct_output_dir, "impact_raw", direct_impact_filename)
+        df.loc[i, 'direct_impact_path'] = direct_impact_path
 
-    for run in config["runs"]:
-        for scenario_year in run["scenario_years"]:
-            run_pipeline(
-                run["countries"],
-                [run["hazard"]],
-                run["sectors"],
-                scenario_year["scenario"],
-                scenario_year["ref_year"],
-                config["n_sim_years"],
-                config["io_approach"],
-                seed=config["seed"],
-                direct_output_dir=direct_output_dir,
-                indirect_output_dir=indirect_output_dir,
-                business_interruption=config["apply_business_interruption"],
-                calibrated=config['use_calibrated_impfs']
-            )
+        yearset_filename = folder_naming.get_direct_namestring(
+            prefix='yearset',
+            extension='hdf5',
+            haz_type=row['hazard'],
+            sector=row['sector'],
+            scenario=row['scenario'],
+            ref_year=row['ref_year'],
+            country_iso3alpha=row['country']
+        )
+        yearset_path = Path(direct_output_dir, "yearsets", yearset_filename)
+        df.loc[i, 'yearset_path'] = yearset_path
+
+    return df
+
+
+def create_single_yearset(
+        analysis_spec: pd.DataFrame,
+        n_sim_years: int,
+        seed: int,
+        ):
+    """Take the metadata for an analysis and create an impact yearset if it 
+    doesn't already exist. These are created as files and a `yearset_path` added
+    to the input dataframe. 
+
+    Parameters
+    ----------
+    analysis_spec : pd.Series
+        A row of a dataframe created by config_to_dataframe
+    n_sim_years : int
+        Number of years to create for each output yearset
+    seed : int
+        The random number seed to use in each yearset's sampling
+    """
+
+    row = analysis_spec.copy().to_dict()
+
+    print(f'Generating yearsets for {row["yearset_path"]}')
+    imp = get_impact_from_file(row['direct_impact_path'])
+
+    # TODO we don't actually want to generate a yearset if we're looking at observed events
+    imp_yearset = yearset_from_imp(
+        imp,
+        n_sim_years,
+        cap_exposure=get_sector_exposure(row['sector'], row['country']),
+        seed=seed
+    )
+
+    # TODO drop the impact matrix to save file space once petals is updated
+    # future work will make the impact matrix unnecessary!
+    if False:
+        del imp_yearset.imp_mat
+
+    return imp_yearset
+
+
+def df_create_combined_hazard_yearsets(
+        df: pd.DataFrame
+    ):
+    """For each grouping of scenario, country and sector, combine hazard yearsets 
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Dataframe containing analyses metadata created by config_to_dataframe
+
+    Returns
+    -------
+    pandas.DataFrame
+        A dataframe containing analysis metadata for a supply chain analysis 
+        for all hazards combined.
+
+    Notes
+    -----
+    This function adapts pymrio.tools.iomath.calc_x to compute
+    value added (v).
+    """
+    
+    r = df.iloc[0].to_dict()
+    yearset_output_dir = os.path.dirname(r['yearset_path'])
+    print(r)
+    combined_filename = folder_naming.get_direct_namestring(
+            prefix='yearset',
+            extension='hdf5',
+            haz_type='COMBINED', sector=r['sector'], scenario=r['scenario'], ref_year=r['ref_year'], country_iso3alpha=r['country'])
+    combined_path = Path(yearset_output_dir, combined_filename)
+
+    impact_list = [get_impact_from_file(f) for f in df['yearset_path'] if os.path.exists(f)]
+
+    out = {
+        'hazard': 'COMBINED',
+        'scenario': r['scenario'], 
+        'ref_year': r['ref_year'],
+    }
+
+    if len(impact_list) > 0:
+        combined = combine_yearsets(
+            impact_list = impact_list,
+            cap_exposure = get_sector_exposure(r['sector'], r['country'])
+        )
+        
+        # TODO drop the impact matrix to save file space once petals is updated
+        # future work will make the impact matrix unnecessary!
+        if False:
+            del combined.imp_mat  # drop this to save file space!
+
+        combined.write_hdf5(combined_path)
+
+        out['yearset_path'] = combined_path
+        out['_yearset_exists'] = True
+        # out['annual_impacts'] = combined.at_event
+    else:
+        out['_yearset_exists'] = False
+
+    return pd.Series(out)
+
+
+
+def exists_impact_file(filepath: str, use_s3: bool = False):
+    """Check if an impact object exists at a filepath, checking the corresponding 
+    location on the S3 bucket if requested if the file is not present locally.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to requested file
+    use_s3 : bool
+        If True, check for a file with this name on the s3 bucket as well 
+
+    Returns
+    -------
+    bool
+        Whether the impact file exists
+    """
+    if os.path.exists(filepath):
+        return True
+    if use_s3:
+        filename = os.path.basename(filepath)
+        return file_exists_on_s3_bucket(filepath)
+    return False
+
+
+def get_impact_from_file(filepath: str, use_s3: bool = False):
+    """Load an impact object from a filepath, checking the corresponding 
+    location on the S3 bucket if requested if the file is not present locally.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to requested file
+    use_s3 : bool
+        If True, check for a file with this name on the s3 bucket as well 
+
+    Returns
+    -------
+    climada.engine.impact.Impact
+        CLIMADA Impact object loaded from the filepath
+    """
+    if os.path.exists(filepath):
+        return Impact.from_hdf5(filepath)
+    if use_s3:
+        filename = os.path.basename(filepath)
+        download_from_s3_bucket(s3_filename=filename, output_path=filepath)
+        return Impact.from_hdf5(filepath)
+    raise FileExistsError(f"Could not find an impact object at {filepath}")
+
+
+def write_impact_to_file(imp, filepath: str, use_s3: bool = False):
+    imp.write_hdf5(filepath)
+    if use_s3:
+        filename = os.path.basename(filepath)
+        upload_to_s3_bucket(filename)  
+
+
+def _check_config_valid_for_indirect_aggregations(config):
+    # Check all scenarios lists are the same length OR length 1
+    scenarios_list_list = [run['scenario_years'] for run in config['runs']]
+    n_scenarios_list = [len(scenario_list) for scenario_list in scenarios_list_list if len(scenario_list) > 1]
+    if len(np.unique(n_scenarios_list)) > 1:
+        raise ValueError('To continue with generation of yearsets and indirect impacts, the config needs to have the '\
+                         'same number of scenarios specified for each hazard in the config, or just one scenario.')
+    return 1 if len(n_scenarios_list) == 0 else n_scenarios_list[0]
 
 
 if __name__ == "__main__":

--- a/analysis.py
+++ b/analysis.py
@@ -125,6 +125,8 @@ def run_pipeline_from_config(
                 pool.map(calc_partial, df_chunked)    
         else:
             calculate_direct_impacts_from_df(analysis_df, use_s3)
+    else:
+        print("Skipping direct impact calculations. Change DO_DIRECT in analysis.py to change this")
 
     analysis_df['_direct_impact_exists'] = [exists_impact_file(p, use_s3) for p in analysis_df['direct_impact_path']]
     analysis_df.to_csv(Path(direct_output_dir, 'calculations_report.csv'))
@@ -166,6 +168,8 @@ def run_pipeline_from_config(
                 pool.map(calc_partial, df_chunked)    
         else:
             calculate_yearsets_from_df(analysis_df, config, use_s3)
+    else:
+        print("Skipping yearset calculations. Change DO_YEARSETS in analysis.py to change this")
 
     analysis_df['_yearset_exists'] = [exists_impact_file(p, use_s3) for p in analysis_df['yearset_path']]
     analysis_df.to_csv(Path(direct_output_dir, 'calculations_report.csv'))
@@ -185,6 +189,8 @@ def run_pipeline_from_config(
             .reset_index()
 
         analysis_df = pd.concat([analysis_df, df_aggregated_yearsets]).reset_index()  # That's right! I don't know how to use reset_index!
+    else:
+        print("Skipping multihazard impact calculations. Change DO_MULTIHAZARD in analysis.py to change this")
 
     ### ----------------------------------- ###
     ### CALCULATE INDIRECT ECONOMIC IMPACTS ###
@@ -279,6 +285,8 @@ def run_pipeline_from_config(
                     pool.map(calc_partial, df_chunked)  
             else:
                 calculate_indirect_impacts_from_df(analysis_df, io_a, config, direct_output_dir)
+    else:
+        print("Skipping supply chain calculations. Change DO_INDIRECT in analysis.py to change this")
 
     analysis_df.to_csv(Path(indirect_output_dir, 'calculations_report.csv'))
 

--- a/analysis.py
+++ b/analysis.py
@@ -109,12 +109,13 @@ def run_pipeline_from_config(config):
         for scenario_year in run["scenario_years"]:
             run_pipeline(
                 run["countries"],
-                run["hazard"],
+                [run["hazard"]],
                 run["sectors"],
                 scenario_year["scenario"],
                 scenario_year["ref_year"],
                 config["n_sim_years"],
-                run["io_approach"],
+                config["io_approach"],
+                seed=config["seed"],
                 direct_output_dir=direct_output_dir,
                 indirect_output_dir=indirect_output_dir,
                 business_interruption=config["apply_business_interruption"],

--- a/pipeline/direct/calc_yearset.py
+++ b/pipeline/direct/calc_yearset.py
@@ -1,6 +1,11 @@
 import numpy as np
-from climada.util import yearsets
+import copy
 from scipy import sparse
+from functools import reduce
+
+from climada.entity import Exposures
+from climada.engine import Impact, ImpactCalc
+from climada.util import yearsets
 
 
 # THIS IS A QUICK FIX FOR A MORE COMPLEX PROBLEM
@@ -48,16 +53,7 @@ def sample_from_poisson(n_sampled_years, lam, seed=None):
 yearsets.sample_from_poisson = sample_from_poisson
 
 
-def nccs_yearsets_simple(impact_list, n_sim_years, seed=None):
-    '''
-    Generate yearsets from a list of impact objects.
-    TODO: Make this more complex so that the year sampling is consistent across hazards
-    i.e. when Cyclone X is selected in year Y for one yearset, it is selected in all cyclone yearsets
-    '''
-    return [yimp_from_imp_simple(imp, n_sim_years, seed=seed) for imp in impact_list]
-
-
-def yimp_from_imp_simple(imp, n_sim_years, seed=None):
+def yearset_from_imp(imp, n_sim_years, cap_exposure=1, seed=None):
     if np.all(imp.frequency == 1):
         lam = 1 
     else:
@@ -70,6 +66,11 @@ def yimp_from_imp_simple(imp, n_sim_years, seed=None):
         correction_fac=False,
         seed=seed
     )
+
+    # TODO remove this once it's added to yearsets core
+    yimp.event_name = [str(y) for y in range(1, n_sim_years + 1)]
+
+    # TODO extend CLIMADA's yearsets class with this: it should generate this matrix automatically!
     yimp.imp_mat = sparse.csr_matrix(
         np.vstack(
             [imp.imp_mat[samp_vec[i]].sum(0)
@@ -77,4 +78,89 @@ def yimp_from_imp_simple(imp, n_sim_years, seed=None):
              ]
         )
     )
+
+    # TODO extend CLIMADA's yearsets (or possibly Impact) class with this too!
+    yimp = cap_impact(yimp, cap_exposure)
+
     return yimp
+
+
+# Adapted from Zélie's code:
+# https://github.com/CLIMADA-project/climada_papers/blob/main/202403_multi_hazard_risk_assessment/python_scripts/multi_risk.py
+def combine_yearsets(impact_list, how='sum', occur_together=False, cap_exposure=None):
+    """
+    Parameters
+    ----------
+    impact_list : list  or dict of impacts
+    how : how to combine the impacts, options are 'sum', 'max' or 'min'
+    exp : If the exposures are given, the impacts are caped at their value. If a single value is given, all impacts are capped to this value.
+
+    Returns
+    -------
+    imp : Impact
+        Combined impact
+    """
+
+    if type(impact_list) is dict:
+        impact_list = list(impact_list.values())
+
+    if how == 'sum':
+        f = lambda m1, m2: m1 + m2
+    elif how == 'min':
+        f = lambda m1, m2: m1.minimum(m2)
+    elif how == 'max':
+        f = lambda m1, m2: m1.maximum(m2)
+    else:
+        raise ValueError(f"'{how}' is not a valid method. The implemented methods are sum, max or min")
+
+    imp_mat = reduce(f, [imp.imp_mat for imp in impact_list])
+
+    if occur_together:
+        mask_list = [np.abs(impact.imp_mat.A[imp_mat.nonzero()]) == 0 for impact in impact_list]
+        for mask in mask_list:
+            imp_mat.data[mask] = 0
+        imp_mat.eliminate_zeros()
+
+    imp0 = impact_list[0]
+    freq = np.ones(len(imp0.event_id)) / len(imp0.event_id)
+    eai_exp = ImpactCalc.eai_exp_from_mat(imp_mat, freq)
+    at_event = ImpactCalc.at_event_from_mat(imp_mat)
+    aai_agg = ImpactCalc.aai_agg_from_eai_exp(eai_exp)
+
+    imp_combined = Impact(
+        event_id=imp0.event_id,
+        event_name=imp0.event_name,
+        date=imp0.date,
+        frequency=freq,
+        frequency_unit=imp0.frequency_unit,
+        coord_exp=imp0.coord_exp,
+        crs=imp0.crs,
+        eai_exp=eai_exp,
+        at_event=at_event,
+        tot_value=imp0.tot_value,
+        aai_agg=aai_agg,
+        unit=imp0.unit,
+        imp_mat=imp_mat,
+        haz_type='COMBINED'
+    )
+    if cap_exposure is not None:
+        imp_combined = cap_impact(imp_combined, cap_exposure)
+    return imp_combined
+
+
+# TODO add this to CLIMADA in either Impact or Yearsets
+# TODO then get yearsets.impact_yearset to use it!
+def cap_impact(imp, cap_exposure):
+    imp_mat = imp.imp_mat
+    shape = imp_mat.shape
+    m1 = imp_mat.data
+    if isinstance(cap_exposure, Exposures):
+        m2 = cap_exposure.gdf.reset_index().value[imp_mat.nonzero()[1]]
+    else:
+        m2 = cap_exposure
+
+    imp_mat = sparse.csr_matrix((np.minimum(m1, m2), imp_mat.indices, imp_mat.indptr), shape=shape)
+
+    imp_mat.eliminate_zeros()
+    imp.imp_mat = imp_mat
+    return imp

--- a/pipeline/direct/direct.py
+++ b/pipeline/direct/direct.py
@@ -214,6 +214,7 @@ def apply_sector_impf_set(hazard, sector, country_iso3alpha, business_interrupti
     raise ValueError(f'No impact functions defined for hazard {hazard}')
 
 
+
 def get_sector_impf_tc(country_iso3alpha, sector_bi, calibrated=True):
     _, impf_ids, _, region_mapping = ImpfSetTropCyclone.get_countries_per_region()
     region = [region for region, country_list in region_mapping.items() if country_iso3alpha in country_list]

--- a/pipeline/direct/test/test_calc_yearset.py
+++ b/pipeline/direct/test/test_calc_yearset.py
@@ -3,7 +3,7 @@ import numpy as np
 from copy import deepcopy
 from scipy import sparse
 
-from pipeline.direct.calc_yearset import nccs_yearsets_simple
+from pipeline.direct.calc_yearset import yearset_from_imp
 from pipeline.direct.test.create_test_impact import dummy_impact, dummy_impact_yearly
 
 seed = 1312
@@ -19,41 +19,35 @@ class TestYearsets(unittest.TestCase):
 
     def test_yearset_with_poisson_process(self):
         """Yearsets have their basic functionality working"""
-        yimp = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
+        yimp = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, cap_exposure=1, seed=seed)
         np.testing.assert_array_almost_equal(self.dummy_imp.imp_mat.shape, (6, 2))
-        np.testing.assert_array_almost_equal(yimp[0].imp_mat.shape, (self.n_sim_years, 2))
+        np.testing.assert_array_almost_equal(yimp.imp_mat.shape, (self.n_sim_years, 2))
         # The max yearset impact is greater than any individual event (with this seed)
-        self.assertTrue(np.max(self.dummy_imp.at_event) < np.max(yimp[0].at_event))
+        self.assertTrue(np.max(self.dummy_imp.at_event) < np.max(yimp.at_event))
 
     def test_yearset_with_non_poisson_process(self):
         """Our implementation of yearsets can handle sampling event sets where we always want exactly one event per year"""
-        yimp = nccs_yearsets_simple([self.dummy_imp_yearly], n_sim_years = self.n_sim_years, seed=seed)
+        yimp = yearset_from_imp(self.dummy_imp_yearly, n_sim_years = self.n_sim_years, cap_exposure=1, seed=seed)
         np.testing.assert_array_almost_equal(self.dummy_imp_yearly.imp_mat.shape, (6, 2))
-        np.testing.assert_array_almost_equal(yimp[0].imp_mat.shape, (self.n_sim_years, 2))
+        np.testing.assert_array_almost_equal(yimp.imp_mat.shape, (self.n_sim_years, 2))
         # The max yearset impact is the same as the source impact (with this seed)
-        self.assertTrue(np.max(self.dummy_imp_yearly.at_event) == np.max(yimp[0].at_event))
-
-    def test_yearsets_sample_consistently_across_impacts(self):
-        """Yearsets use the same sampling method for each impact object they're given"""
-        yimp1 = nccs_yearsets_simple([self.dummy_imp, self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
-        yimp2 = nccs_yearsets_simple([self.dummy_imp_yearly, self.dummy_imp_yearly], n_sim_years = self.n_sim_years, seed=seed)
-        np.testing.assert_allclose(yimp1[0].at_event, yimp1[1].at_event)
-        np.testing.assert_allclose(yimp2[0].at_event, yimp2[1].at_event)
+        self.assertTrue(np.max(self.dummy_imp_yearly.at_event) == np.max(yimp.at_event))
 
     def test_yearsets_sample_consistently_when_repeated(self):
         """If we generate yearsets a second time with the same seed we get the same sampling"""
-        yimp1 = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
-        yimp2 = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
-        yimp3 = nccs_yearsets_simple([self.dummy_imp, self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
-        np.testing.assert_allclose(yimp1[0].at_event, yimp2[0].at_event)
-        np.testing.assert_allclose(yimp1[0].at_event, yimp3[0].at_event)
-        np.testing.assert_allclose(yimp1[0].at_event, yimp3[1].at_event)
+        yimp1 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, cap_exposure=1, seed=seed)
+        yimp2 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, cap_exposure=1, seed=seed)
+        np.testing.assert_allclose(yimp1.at_event, yimp2.at_event)
 
     def test_yearsets_sample_differently_without_a_seed(self):
         """...but if we don't set the seed we get a different sampling"""
-        yimp1 = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years, seed=seed)
-        yimp2 = nccs_yearsets_simple([self.dummy_imp], n_sim_years = self.n_sim_years)
-        self.assertFalse(np.all(yimp1[0].at_event == yimp2[0].at_event))
+        yimp1 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, cap_exposure=1, seed=seed)
+        yimp2 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years)
+        self.assertFalse(np.all(yimp1.at_event == yimp2.at_event))
+    
+    def test_yearsets_can_cap_exposures(self):
+        # TODO
+        pass
 
 
 if __name__ == '__main__':

--- a/run_configurations/config.py
+++ b/run_configurations/config.py
@@ -7,8 +7,8 @@ CONFIG = {
     "run_title": "refin_exposures_uncal_12_04_2024",
     "io_approach": ["leontief", "ghosh"],
     "n_sim_years": 100,
-    "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
-    "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
+    "calibrated": True,               # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
     "seed": 161,
     "runs": [
         {

--- a/run_configurations/config.py
+++ b/run_configurations/config.py
@@ -9,6 +9,7 @@ CONFIG = {
     "n_sim_years": 100,
     "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
     "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "seed": 161,
     "runs": [
         {
             "hazard": "tropical_cyclone",

--- a/run_configurations/config.py
+++ b/run_configurations/config.py
@@ -5,13 +5,13 @@ either not yet fully developed (windstorms) or has not yet been decided which co
 #TODO add also other subsector to the configuration list
 CONFIG = {
     "run_title": "refin_exposures_uncal_12_04_2024",
+    "io_approach": ["leontief", "ghosh"],
     "n_sim_years": 100,
     "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
     "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
     "runs": [
         {
             "hazard": "tropical_cyclone",
-            "io_approach": ["leontief", "ghosh"],
             "sectors": ["agriculture", "forestry", "mining", "manufacturing", "service", "energy", "water", "waste",
                         "basic_metals", "pharmaceutical", "food", "wood", "chemical", "rubber_and_plastic",
                         "non_metallic_mineral", "refin_and_transform"],
@@ -74,7 +74,6 @@ CONFIG = {
         },
         {
             "hazard": "river_flood",
-            "io_approach": ["leontief", "ghosh"],
             "sectors": ["agriculture", "forestry", "mining", "manufacturing", "service", "energy", "water", "waste",
                         "basic_metals", "pharmaceutical", "food", "wood", "chemical", "rubber_and_plastic",
                         "non_metallic_mineral", "refin_and_transform"],
@@ -138,7 +137,6 @@ CONFIG = {
         },
         {
             "hazard": "wildfire",
-            "io_approach": ["leontief", "ghosh"],
             "sectors": ["agriculture", "forestry", "mining", "manufacturing", "service", "energy", "water", "waste",
                         "basic_metals", "pharmaceutical", "food", "wood", "chemical", "rubber_and_plastic",
                         "non_metallic_mineral", "refin_and_transform"],
@@ -190,7 +188,6 @@ CONFIG = {
         },
         {
             "hazard": "storm_europe",
-            "io_approach": ["leontief", "ghosh"],
             "sectors": ["agriculture", "forestry", "mining", "manufacturing", "service", "energy", "water", "waste",
                         "basic_metals", "pharmaceutical", "food", "wood", "chemical", "rubber_and_plastic",
                         "non_metallic_mineral", "refin_and_transform"],
@@ -214,7 +211,6 @@ CONFIG = {
 
         {
             "hazard": "relative_crop_yield",
-            "io_approach": ["leontief", "ghosh"],
             "sectors": ["agriculture"],
             "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
                           'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh',

--- a/run_configurations/config_interim.py
+++ b/run_configurations/config_interim.py
@@ -6,8 +6,8 @@ either not yet fully developed (windstorms) or has not yet been decided which co
 CONFIG = {
     "run_title": "interim_report_31_05_24",
     "n_sim_years": 300,
-    "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
-    "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
+    "calibrated": True,               # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
     "runs": [
         {
             "hazard": "tropical_cyclone",

--- a/run_configurations/test/test_config.py
+++ b/run_configurations/test/test_config.py
@@ -4,12 +4,15 @@ It doesn't look at the whole pipeline functionality!
 """
 
 CONFIG = {
-    "run_title": "testing",
+    "run_title": "unittest",
     "n_sim_years": 10,
+    "io_approach": ["ghosh"],
+    "business_interruption": True,
+    "calibrated": True,
+    "seed": 42,
     "runs": [
         {
             "hazard": "tropical_cyclone",
-            "io_approach": ["ghosh"],
             "sectors": ["service", "agriculture"],
             "countries": ["Dominica"],
             "scenario_years": [
@@ -18,7 +21,6 @@ CONFIG = {
         },
         {
             "hazard": "storm_europe",
-            "io_approach": ["leontief"],
             "sectors": ["mining", "forestry"],
             "countries": ["Andorra"],
             "scenario_years": [

--- a/run_configurations/test_config.py
+++ b/run_configurations/test_config.py
@@ -7,8 +7,8 @@ CONFIG = {
     "run_title": "test_run",
     "n_sim_years": 300,
     "io_approach": ["ghosh"],
-    "apply_business_interruption": False,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
-    "use_calibrated_impfs": False,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
+    "calibrated": True,               # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
     "seed": 161,
     "runs": [
         {
@@ -26,8 +26,8 @@ CONFIG2 = {
     "run_title": "test_run",
     "n_sim_years": 300,
     "io_approach": ["ghosh"],
-    "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
-    "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
+    "calibrated": True,               # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
     "seed": 161,
     "runs": [
         {
@@ -45,8 +45,8 @@ CONFIG3 = {
     "run_title": "test_run",
     "n_sim_years": 300,
     "io_approach": ["ghosh"],
-    "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
-    "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
+    "calibrated": True,               # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
     "seed": 161,
     "runs": [
         {
@@ -64,8 +64,8 @@ CONFIG4 = {
     "run_title": "test_run",
     "n_sim_years": 300,
     "io_approach": ["ghosh"],
-    "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
-    "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
+    "calibrated": True,               # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
     "seed": 161,
     "runs": [
         {
@@ -84,8 +84,8 @@ CONFIG5 = {
     "run_title": "test_run",
     "n_sim_years": 300,
     "io_approach": ["leontief", "ghosh"],
-    "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
-    "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
+    "calibrated": True,               # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
     "seed": 161,
     "runs": [
         {

--- a/run_configurations/test_config.py
+++ b/run_configurations/test_config.py
@@ -6,12 +6,13 @@ either not yet fully developed (windstorms) or has not yet been decided which co
 CONFIG = {
     "run_title": "test_run",
     "n_sim_years": 300,
+    "io_approach": ["ghosh"],
     "apply_business_interruption": False,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
     "use_calibrated_impfs": False,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "seed": 161,
     "runs": [
         {
             "hazard": "tropical_cyclone",
-            "io_approach": ["ghosh"],
             "sectors": ["manufacturing"],
             "countries": ['United States', 'Ireland', 'Japan', 'Taiwan, Province of China', 'China', 'Korea, Republic of'],
             "scenario_years": [
@@ -24,12 +25,13 @@ CONFIG = {
 CONFIG2 = {
     "run_title": "test_run",
     "n_sim_years": 300,
+    "io_approach": ["ghosh"],
     "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
     "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "seed": 161,
     "runs": [
         {
             "hazard": "river_flood",
-            "io_approach": ["ghosh"],
             "sectors": ["manufacturing"],
             "countries": ['China','Germany','Burundi','Italy'],
             "scenario_years": [
@@ -42,12 +44,13 @@ CONFIG2 = {
 CONFIG3 = {
     "run_title": "test_run",
     "n_sim_years": 300,
+    "io_approach": ["ghosh"],
     "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
     "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "seed": 161,
     "runs": [
         {
             "hazard": "wildfire",
-            "io_approach": ["ghosh"],
             "sectors": ["manufacturing"],
             "countries": ['Italy','China','Russian Federation'],
             "scenario_years": [
@@ -60,8 +63,10 @@ CONFIG3 = {
 CONFIG4 = {
     "run_title": "test_run",
     "n_sim_years": 300,
+    "io_approach": ["ghosh"],
     "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
     "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "seed": 161,
     "runs": [
         {
             "hazard": "storm_europe",
@@ -78,12 +83,13 @@ CONFIG4 = {
 CONFIG5 = {
     "run_title": "test_run",
     "n_sim_years": 300,
+    "io_approach": ["leontief", "ghosh"],
     "apply_business_interruption": True,    # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducing old results
     "use_calibrated_impfs": True,           # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducing old results
+    "seed": 161,
     "runs": [
         {
             "hazard": "relative_crop_yield",
-            "io_approach": ["ghosh", "leontief"],
             "sectors": ["agriculture"],
             "countries": ['Canada','Egypt', 'Portugal','Pakistan','Armenia','Belarus','Peru'],
             "scenario_years": [

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -5,12 +5,15 @@ Test the analysis pipeline runs
 import unittest
 from analysis import run_pipeline_from_config
 from run_configurations.test.test_config import CONFIG  # change here to test_config if needed
+from utils.folder_naming import get_direct_output_dir
+from utils.delete_results import delete_results_folder
 
 class TestAnalysisPipeline(unittest.TestCase):
     
     # Simplest possible test: check it runs without errors
     # TODO: less simple possible tests 
     def test_pipeline_runs(self):
+        delete_results_folder(CONFIG['run_title'])
         _ = run_pipeline_from_config(CONFIG)
 
 

--- a/utils/delete_results.py
+++ b/utils/delete_results.py
@@ -1,0 +1,12 @@
+import os
+from utils import folder_naming
+from shutil import rmtree
+
+def delete_results_folder(run_title):
+    run_dir = folder_naming.get_run_dir(run_title)
+    if os.path.exists(run_dir):
+        print(f'Removing results in {run_dir}')
+        rmtree(run_dir)
+    else:
+        print(f'No results to remove in {run_dir}')
+    

--- a/utils/folder_naming.py
+++ b/utils/folder_naming.py
@@ -32,3 +32,13 @@ def get_direct_output_dir(run_title):
 
 def get_indirect_output_dir(run_title):
     return f"{OUTPUT_DIR}/{run_title}/indirect"
+
+
+def get_direct_namestring(prefix, extension, haz_type, sector, scenario, ref_year, country_iso3alpha):
+    return f"{prefix}" \
+           f"_{haz_type}" \
+           f"_{sector.replace(' ', '_')[:15]}" \
+           f"_{scenario}" \
+           f"_{ref_year}" \
+           f"_{country_iso3alpha}" \
+           f".{extension}"

--- a/utils/folder_naming.py
+++ b/utils/folder_naming.py
@@ -8,7 +8,7 @@ def get_resource_dir():
     Returns the absolute path to the exposures directory
     :return:
     """
-    return os.path.abspath(f"{os.path.dirname(os.path.abspath(__file__))}/../exposures")
+    return os.path.abspath(f"{os.path.dirname(os.path.abspath(__file__))}/../resources")
 
 def get_resources_dir():
     """


### PR DESCRIPTION
This changes a looooot of stuff.

Have a look. Since I've encoded a lot of my own opinions here I'm very open to making changes, even big changes, since I know there are other directions we could take here.

Most of the changes affect analysis.py and how it does the overhead to administrate the modelling chain, and to direct.py. The indirect side of things is (mostly) unchanged.

Happy to answer any questions. If things aren't clear, post here and ping me on Teams, or just ping me on Teams, rather than spending ages figuring it out.

# Main goals

There are some practical and some philosophical ideas that guided this. I hope this help while you look through it.

### Practical goals
- **Reduce RAM usage:** For large analyses, we were storing a lot of data in memory. That's impractical. At the expense of a bit of time and a lot of disk storage (up to hundreds of MB per run, so far), the analysis.py script now saves its intermediate data to disk and then reads it back when it needs it. That means that for large multi-hazard, multi-country calculations, only one scenario-sector-country-hazard combination needs to be in memory at a time.
- **Interrupt and restart calculations:** I wanted to be able to start and stop calculations and I wanted not to restart from zero if a calculation crashed part way through. With the above change saving intermediate data to files, it meant that analyses can read in the CONFIG and see what is already calculated. Most steps of the calculation start by checking for the relevant intermediate file and use it if it's available.
- **Better oversight of the jobs run:** I felt it was hard to keep track of everything that was being calculated, and what was succeeding and failing. The analysis.py script now creates a big data frame `analysis_df` with each row containing the parameters needed to call the methods that will run the analysis (along with the CONFIG), plus information about whether the intermediate files already exist, plus information about which calculations will be run (since certain parts of the calculation chain can be turned on and off). 
  - This approach also allows for easier parallelisation, rather than trying to parallelise in nested `for` loops.

### Philosophical goals
- As much as possible I wanted to separate the administrative overhead of the run from the functions that do the analysis and calculations. Therefore:
    - Anything administrative that's looping through sectors/scenarios/countries/etc and managing overhead or I/O is in analysis.py.
    - Anything that analyses, combines or creates data is in the respective direct/ or indirect/ packages. The idea is that all the functions here can be called in other situations too: they don't need you to have an `analysis_df` dataframe, just the relevant parameters.
- Related, a lot of functions took lists of hazards, or exposures and looped through them to do all the necessary calculations. As far as possible I've removed these, so that all looping takes place through the rows of `analysis_df` and all calculations are for a single hazard-sector-scenario-country combination. (One exception is the IO approach where we still loop through both). When you see whole functions that are deleted, this is usually why.


# Nitty gritty details

Some of the things the refactor does:
- There are changes to the structure of the config files
  - The io_approach parameter (for choosing Leontief, Ghosh or both) is part of the config now, rather than specified for each individual run. I don't think we ever need to run different approaches for different hazards. Let me know if not!
  - There are three new parameters:
    - business_interruption: include business interruption in the impact functions. Default True
    - calibrated: use calibrated impact functions. Default True
    - seed: random seed (for reproducibility)
- There's a very simple integration test in test/test_analysis.py. It runs a simple pipeline. Use it to check that everything is working. It's a unit test so you can run it from the command line with `python -m unittest`. The config for it is stored in run_configurations/test/test_config.py – feel free to edit.
- analysis.py's `run_pipeline_from_config` starts by creating this `analysis_df` dataframe. All calculations are coordinated and run from the data in this dataframe and in the config object 
- analysis.py now has some settings at the start to turn on and off different parts of the calculation. I've put them here rather than in the config because they don't affect the actual results. The flags
  - DO_PARALLEL: turn on/off parallelisation (since it doesn't work on Windows yet). Default True
  -  DO_DIRECT: do/skip direct impacts that haven't yet been calculated. Default True
  - DO_YEARSETS: do/skip creation of direct impact yearsets that haven't yet been calculated. Default True
  - DO_MULTIHAZARD: do/skip the creation of combined hazards and the related supply chain runs. Default False
  - DO_INDIRECT: do/skip supply chain calculations that haven't yet been calculated. Default True
- You'll see a few kinda dumb functions called `calculate_*_from_df` that take a dataframe and run methods from direct.py on each row. These mostly exist to make parallelisation work, since I have to chunk the dataframe and run things on each chunk. It's a bit clunky and I think I'd like to replace it with a multithreading approach which woould be simpler. But not today.
- There are a few changes to how yearset Impact objects are created. Each event in the yearset represents one plausible year of events and is created by sampling from our probabilistic event set (either once, if our each event in the event set is one year, e.g. windstorm, or many times if multiple events can occur in a year, e.g. tropical storms). In the case of the latter it's possible that multiple events in the same location could result in >100% loss, and we cap the losses at 100%
- A few methods have `use_s3` implemented to read and save from S3. This isn't complete yet.
- There are some changes to the storm_europe data creation. Don't worry about these, they're not part of the pipeline and might need rewriting anyway since CLIMADA changed how Centroids (and especially gridded data) work.

### One worry
I can't remember if my implementation here now depends on a very particular version of the yearsets in CLIMADA Petals. If you run the pipeline and get an error to do with Impacts or yearsets this is probably what's happening. Let me know!