### PR TITLE
If file already exists, don't download from S3

### DIFF
--- a/utils/s3client.py
+++ b/utils/s3client.py
@@ -34,7 +34,7 @@ def get_client():
     )
 
 
-def download_from_s3_bucket(s3_filename: str, output_path: typing.Union[str, None] = None):
+def download_from_s3_bucket(s3_filename: str, output_path: typing.Union[str, None] = None, overwrite=False):
     """
     Downloads a file from the S3 bucket.
     if no output_path is provided, the file is downloaded to the current working directory.
@@ -46,7 +46,12 @@ def download_from_s3_bucket(s3_filename: str, output_path: typing.Union[str, Non
     if output_path is None:
         output_path = s3_filename
 
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    if not overwrite and os.path.exists(output_path):
+        return
+
+    dirname = os.path.dirname(output_path)
+    if dirname != '':
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     s3 = get_client()
     return s3.download_file(


### PR DESCRIPTION
During the calibration we run the same code many times and don't want to redownload things every time. If the target file already exists on the local file system, it's not downloaded from S3.

Open for discussion about whether this check should be inside the download method or somewhere else!

Also added the 'overwrite' parameter to the download method that lets you download even if the file exists locally. It's not used anywhere but we could potentially add it to the config.

Also a little bugfix where downloading to a target path in the current directory threw an error when creating the target download directory.