### PR TITLE
Wrap the CLIMADA API Client to check for cached data before it redownloads

### DIFF
--- a/climada.conf
+++ b/climada.conf
@@ -1,0 +1,10 @@
+{
+    "_comment": "this sets up CLIMADA for use with the NCCS pipeline. The file here overwrites any settings you've changed in climada.conf files within your climada installation or in your home directory",
+    "_comment": "Note: the log_level will be automatically overwritten when the analysis pipeline is run",
+    "log_level": "WARNING",
+    "data_api": {
+        "cache_db": "{local_data.system}/.downloads.db",
+        "cache_enabled": true,
+        "cache_dir": "{local_data.system}/.apicache"
+    }
+}

--- a/pipeline/direct/agriculture.py
+++ b/pipeline/direct/agriculture.py
@@ -3,7 +3,7 @@ import typing
 import numpy as np
 from climada.entity import ImpactFunc
 from climada.entity import ImpactFuncSet
-from climada.util.api_client import Client
+from utils.climada_api import NCCSClimadaClient as Client
 from climada_petals.entity.impact_funcs.relative_cropyield import ImpfRelativeCropyield
 from pycountry import countries
 

--- a/pipeline/direct/direct.py
+++ b/pipeline/direct/direct.py
@@ -13,7 +13,7 @@ from climada.engine.impact_calc import ImpactCalc, Impact
 from climada.entity import Exposures
 from climada.entity import ImpactFuncSet, ImpfTropCyclone, ImpfSetTropCyclone
 from climada.entity.impact_funcs.storm_europe import ImpfStormEurope
-from climada.util.api_client import Client
+from utils.climada_api import NCCSClimadaClient as Client
 from climada_petals.entity.impact_funcs.river_flood import RIVER_FLOOD_REGIONS_CSV, flood_imp_func_set
 from utils.s3client import download_from_s3_bucket
 from exposures.utils import root_dir

--- a/utils/climada_api.py
+++ b/utils/climada_api.py
@@ -1,0 +1,54 @@
+# This file extends CLIMADA Data API Client, allowing the client to check for the existence of already-downloaded 
+# datasets in its cache before it redownloads them.
+#
+# The methods where we want to check the cache first are overloaded in the new class. A decorator @check_cache_first is 
+# added to each of them (with the method's signature staying the same)
+
+
+import logging
+from climada.util.api_client import Client
+
+LOGGER = logging.getLogger(__name__)
+
+class NCCSClimadaClient(Client):
+    def __init__(self, cache_enabled=None):
+        super().__init__(cache_enabled)
+
+    @staticmethod
+    def check_cache_first(func):
+        def wrapper(self, *args, **kwargs):
+            api_logger = logging.getLogger('climada.util.api_client')
+            original_log_level = api_logger.getEffectiveLevel()
+            original_online_status = self.online
+
+            try:
+                if self.cache.enabled:
+                    LOGGER.debug('Checking the cache for existing API data')
+                    self.online = False           # When the client is offline it checks its cache instead of downloading data
+                    api_logger.setLevel('ERROR')  # The client throws a warning when it accesses the cache and we don't want to hear it 
+                    return func(self, *args, **kwargs)
+            except Client.NoConnection:
+                LOGGER.debug('...No data found in the API cache')
+            finally:
+                # Set things back to how they started 
+                api_logger.setLevel(original_log_level)
+                self.online = original_online_status
+
+            # If that didn't work, do it the old fashioned way
+            LOGGER.debug(f'Downloading from the CLIMADA data API via {func.__name__}')
+            return func(self, *args, **kwargs)
+        return wrapper
+    
+    @check_cache_first
+    def get_litpop(self, *args, **kwargs):
+        return super().get_litpop(*args, **kwargs)
+    
+    @check_cache_first
+    def get_exposures(self, *args, **kwargs):
+        return super().get_exposures(*args, **kwargs)
+
+    @check_cache_first
+    def get_hazard(self, *args, **kwargs):
+        return super().get_hazard(*args, **kwargs)
+    
+    # TODO write some tests that run requests in a temporary cache


### PR DESCRIPTION
As part of calibration I'm running the same calculations over and over again. Currently the CLIMADA Data API redownloads the relevant data every time the calculation is run.

This is a bit silly since the CLIMADA API already caches the results of previous calls, so we _could_ just load them from disk. For whatever reason this isn't implemented in the API.

So here I create a wrapper class `NCCSClimadaClient` around the CLIMADA Data API. For each of the methods we're use in the NCCS project I add a decorator that first looks for data in the cache, and only downloads it if we don't already have it.

Also in this pull request is the inclusion of a climada.conf file that lets us override the default options for CLIMADA. The options implemented are
- data api cache enabled: if `False` then CLIMADA doesn't save all the data it downloads. Use this to save disk space!
- location of data api cache (this is currently set to CLIMADA's default location, but if you're running large simulations locally you may want to store this on some external hard drive)
- CLIMADA's warning level. This should have been part of my previous PR about logging but I forgot. Default value is 'WARNING' so that CLIMADA shuts up a bit!