### PR TITLE
Change TC data source for new improved data

### DIFF
--- a/pipeline/direct/direct.py
+++ b/pipeline/direct/direct.py
@@ -9,6 +9,7 @@ import os
 import numpy as np
 import pycountry
 
+from climada.hazard import Hazard
 from climada.engine.impact_calc import ImpactCalc, Impact
 from climada.entity import Exposures
 from climada.entity import ImpactFuncSet, ImpfTropCyclone, ImpfSetTropCyclone
@@ -78,6 +79,13 @@ def download_exposure_from_s3(country,file_short):
     exp.check()
     return exp
 
+
+def download_hazard_from_s3(s3_filepath):
+    outputfile=f'{project_root}/resources/{s3_filepath}'
+    download_from_s3_bucket(s3_filepath, outputfile)
+    haz = Hazard.from_hdf5(outputfile)
+    haz.check()
+    return haz
 
 
 def get_sector_exposure(sector, country):
@@ -305,24 +313,11 @@ def get_hazard(haz_type, country_iso3alpha, scenario, ref_year):
     client = Client()
     if haz_type == 'tropical_cyclone':
         if scenario == 'None' and ref_year == 'historical':
-            return client.get_hazard(
-                'tropical_cyclone',
-                properties={
-                    'country_iso3alpha': country_iso3alpha,
-                    'climate_scenario': 'None',
-                    'event_type': 'synthetic'
-                }
-            )
+            s3_path = f'hazard/tc_wind/historical/tropcyc_{country_iso3alpha}_historical.hdf5'
         else:
-            return client.get_hazard(
-                'tropical_cyclone',
-                properties={
-                    'country_iso3alpha': country_iso3alpha,
-                    'climate_scenario': scenario,
-                    'ref_year': str(ref_year),
-                    'event_type': 'synthetic'
-                }
-            )
+            s3_path = f'hazard/tc_wind/{scenario}_{ref_year}/tropcyc_150arcsec_25synth_{country_iso3alpha}_1980_to_2023_{scenario}_{ref_year}.hdf5'
+        return download_hazard_from_s3(s3_path)
+
     elif haz_type == 'river_flood':
         if scenario == 'None' and ref_year == 'historical':
             return client.get_hazard(


### PR DESCRIPTION
Thanks to Samuel Juhel for generating awesome new TC data for us.

The new files are stored on the S3 bucket and this commit points all tc hazard requests to the bucket.

Note: you may want to clear your local CLIMADA cache which is probably storing all of the old TC files that we won't be using any more.

The cache is by default located at
~/climada/data/hazard/tropical_cyclone

The files here can safely be deleted.