### PR TITLE
Add a climada.conf file to override climada settings

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -58,11 +58,12 @@ def run_pipeline_from_config(
     CONSOLE = logging.StreamHandler(stream=sys.stdout)
     CONSOLE.setFormatter(FORMATTER)
     LOGGER.addHandler(CONSOLE)
+    # Note: the logging level for CLIMADA is set separately in the climada.conf file
 
     if config['log_level'] != CLIMADA_CONFIG.log_level:
         LOGGER.info(
             f'To change the logging level of CLIMADA, edit climada.conf in the root directory and set log_level to INFO or DEBUG.'\
-            'Current level is {CLIMADA_CONFIG.log_level}'
+            f'Current level is {CLIMADA_CONFIG.log_level}'
             )
     
     if config['log_level'] != "DEBUG":

--- a/climada.conf
+++ b/climada.conf
@@ -1,0 +1,11 @@
+{
+    "_comment": "this sets up CLIMADA for use with the NCCS pipeline",
+    "_comment": "The file here overwrites any settings you've changed in other climada.conf files inside climada installation or in your home directory",
+    
+    "log_level": "WARNING",
+
+    "_comment": "The local_data.system parameter is the location for files downloaded from the CLIMADA API, plus some auxiliary files and cache data",
+    "local_data": {
+        "system": "~/climada/data"
+    }
+}


### PR DESCRIPTION
- Edit this file to change the default climada log level
- Edit this file to change where downloaded data from the API are stored

(There are lots of other settings in CLIMADA but they haven't been relevant yet)