### PR TITLE
Evaluate cost functions on different groupings of countries

### DIFF
--- a/calibration/interpolate_return_periods.py
+++ b/calibration/interpolate_return_periods.py
@@ -5,51 +5,59 @@ import pandas as pd
 LOGGER = logging.getLogger(__name__)
 
 
-# Method to take two dataframes of losses by return period and country and interpolate
-# the losses of the first to match the return periods of the second (by country)
+# Method to take two dataframes of losses by return period and country/group and interpolate
+# the losses of the first to match the return periods of the second (by country/group)
 
-def interpolate_return_periods(rp_input, rp_target, left=np.nan, right=np.nan):
+def interpolate_return_periods(rp_input, rp_target, grouping_var='country', left=np.nan, right=np.nan):
     output = []
-    for country in rp_target['country'].unique():
-        rp_input_country = rp_input.loc[rp_input['country'] == country]
-        rp_input_country = rp_input_country[['country', 'rp', 'impact']].sort_values(['rp'], ascending=True)
-        rp_target_country = rp_target.loc[rp_target['country'] == country]
-        rp_target_country = rp_target_country[['country', 'rp', 'impact']].sort_values(['rp'], ascending=True)
+    if not grouping_var:
+        grouping_var = '_group_'
+        rp_input['_group_'] = 1
+        rp_target['_group_'] = 1
+
+    for group in rp_target[grouping_var].unique():
+        rp_input_group = rp_input.loc[rp_input[grouping_var] == group]
+        rp_input_group = rp_input_group[[grouping_var, 'rp', 'impact']].sort_values(['rp'], ascending=True)
+        rp_target_group = rp_target.loc[rp_target[grouping_var] == group]
+        rp_target_group = rp_target_group[[grouping_var, 'rp', 'impact']].sort_values(['rp'], ascending=True)
 
         # Deal with no modelled impacts
-        if rp_input_country.shape[0] == 0:
+        if rp_input_group.shape[0] == 0:
             output.append(
-                pd.DataFrame(dict(
-                    country = country,
-                    rp = rp_target_country['rp'],
-                    impact = np.nan
-                ))
+                pd.DataFrame({
+                    grouping_var: group,
+                    'rp': rp_target_group['rp'],
+                    'impact': np.nan
+                })
             )
         
         else:
             output.append(
-                pd.DataFrame(dict(
-                    country = country,
-                    rp = rp_target_country['rp'],
-                    impact = np.interp(
-                        x = np.array(rp_target_country['rp']),
-                        xp = np.array(rp_input_country['rp']),
-                        fp = np.array(rp_input_country['impact']),
+                pd.DataFrame({
+                    grouping_var: group,
+                    'rp': rp_target_group['rp'],
+                    'impact': np.interp(
+                        x = np.array(rp_target_group['rp']),
+                        xp = np.array(rp_input_group['rp']),
+                        fp = np.array(rp_input_group['impact']),
                         left=left,
                         right=right
                     )
-                ))
+                })
             )
     
     rp = pd.concat(output)
 
-    missing_countries_all_df = rp.groupby('country')[['impact']].apply(lambda x: x.isnull().all())
-    missing_countries_any_df = rp.groupby('country')[['impact']].apply(lambda x: x.isnull().any())
-    missing_countries_all = missing_countries_all_df[missing_countries_all_df['impact'] > 0].index.tolist()
-    missing_countries_any = missing_countries_any_df[missing_countries_any_df['impact'] > 0].index.tolist()
-    if len(missing_countries_all) > 0:
-        LOGGER.warning(f'The cost calculation had no modelled reproductions of observations for {len(missing_countries_all)} countries: {missing_countries_all}')
-    elif len(missing_countries_any) > 0:
-        LOGGER.warning(f'The cost calculation had missing modelled reproductions of observations for {len(missing_countries_any)} countries: {missing_countries_any}')
+    missing_groups_all_df = rp.groupby(grouping_var)[['impact']].apply(lambda x: x.isnull().all())
+    missing_groups_any_df = rp.groupby(grouping_var)[['impact']].apply(lambda x: x.isnull().any())
+    missing_groups_all = missing_groups_all_df[missing_groups_all_df['impact'] > 0].index.tolist()
+    missing_groups_any = missing_groups_any_df[missing_groups_any_df['impact'] > 0].index.tolist()
+    if len(missing_groups_all) > 0:
+        LOGGER.warning(f'The cost calculation had no modelled reproductions of observations for {len(missing_groups_all)} groups: {missing_groups_all}')
+    elif len(missing_groups_any) > 0:
+        LOGGER.warning(f'The cost calculation had missing modelled reproductions of observations for {len(missing_groups_any)} groups: {missing_groups_any}')
+
+    if grouping_var == '_group_':
+        rp.drop(columns=['_group_'], inplace=True)
 
     return rp

--- a/calibration/rp_errors.py
+++ b/calibration/rp_errors.py
@@ -36,13 +36,14 @@ def rp_rmse(rp_model, rp_obs, grouping_var='country'):
 
 
 def merge_outputs_and_obs(rp_model, rp_obs, grouping_var='country'):
+    rp_model, rp_obs = deepcopy(rp_model), deepcopy(rp_obs)
+    rp_model = interpolate_return_periods(rp_model, rp_obs, grouping_var=grouping_var)
+
     if not grouping_var:
         grouping_var = '_group_'
         rp_model[grouping_var] = 1
         rp_obs[grouping_var] = 1
 
-    rp_model, rp_obs = deepcopy(rp_model), deepcopy(rp_obs)
-    rp_model = interpolate_return_periods(rp_model, rp_obs, grouping_var=grouping_var)
     rp_model = rp_model[[grouping_var, 'rp', 'impact']].rename(columns={'impact': 'model'})
     rp_obs = rp_obs[[grouping_var, 'rp', 'impact']].rename(columns={'impact': 'obs'})
 

--- a/calibration/rp_errors.py
+++ b/calibration/rp_errors.py
@@ -10,9 +10,9 @@ LOGGER = logging.getLogger(__name__)
 
 # Cost function to quantify the difference between modelled and observed model return periods
 
-def rp_rmse(rp_model, rp_obs):
+def rp_rmse(rp_model, rp_obs, grouping_var='country'):
     #Align return periods so that modelled data matches observations
-    rp = merge_outputs_and_obs(rp_model, rp_obs)
+    rp = merge_outputs_and_obs(rp_model, rp_obs, grouping_var)
     
     # DECISION: we use the root mean square error to evaluate model performance (not the log). This means that errors
     # from small events aren't very important and errors from large events dominate the cost function. This is what 
@@ -35,28 +35,34 @@ def rp_rmse(rp_model, rp_obs):
     return root_mean_squared_error(y_true=rp['obs'], y_pred=rp['model'], sample_weight=None)
 
 
-def merge_outputs_and_obs(rp_model, rp_obs):
-    rp_model, rp_obs = deepcopy(rp_model), deepcopy(rp_obs)
-    rp_model = interpolate_return_periods(rp_model, rp_obs)
-    rp_model = rp_model[['country', 'rp', 'impact']].rename(columns={'impact': 'model'})
-    rp_obs = rp_obs[['country', 'rp', 'impact']].rename(columns={'impact': 'obs'})
+def merge_outputs_and_obs(rp_model, rp_obs, grouping_var='country'):
+    if not grouping_var:
+        grouping_var = '_group_'
+        rp_model[grouping_var] = 1
+        rp_obs[grouping_var] = 1
 
-    rp_model['rank'] =  rp_model.groupby('country')['rp'].transform('max') / rp_model['rp']
-    rp_model['rank'] = rp_model['rank'].round().astype(int)
-    rp_obs['rank'] = rp_obs.groupby('country')['rp'].transform('max') / rp_obs['rp']
-    rp_obs['rank'] = rp_obs['rank'].round().astype(int)
+    rp_model, rp_obs = deepcopy(rp_model), deepcopy(rp_obs)
+    rp_model = interpolate_return_periods(rp_model, rp_obs, grouping_var=grouping_var)
+    rp_model = rp_model[[grouping_var, 'rp', 'impact']].rename(columns={'impact': 'model'})
+    rp_obs = rp_obs[[grouping_var, 'rp', 'impact']].rename(columns={'impact': 'obs'})
+
+    rp_model['rank'] = rp_model.sort_values([grouping_var, 'rp'], ascending=[True, False]).groupby(grouping_var).cumcount() + 1
+    rp_obs['rank'] = rp_obs.sort_values([grouping_var, 'rp'], ascending=[True, False]).groupby(grouping_var).cumcount() + 1
 
     # DECISION: we don't care about losses that were modelled by the pipeline but aren't present in the observations
     # This is because the criteria for inclusion in EM-DAT is kind of vague, and many event sets include events much 
     # too small for EM-DAT to find interesting, and often they will occur in the same year as an EM-DAT event, and 
     # therefore in the same footprint
-    rp = pd.merge(rp_obs, rp_model, how="left", on=['country', 'rank']).rename(columns={'rp_x': 'rp'}).drop(columns=['rp_y', 'rank'])    
+    rp = pd.merge(rp_obs, rp_model, how="left", on=[grouping_var, 'rank']).rename(columns={'rp_x': 'rp'}).drop(columns=['rp_y', 'rank'])
+
+    if grouping_var == '_group_':
+        rp.drop(columns=['_group_'], inplace=True)
     return rp
 
 
 # unused
-def rp_rmse_choose_scale(rp_model, rp_obs, scale_bounds=[0, 1]):
-    rp = merge_outputs_and_obs(rp_model, rp_obs)    
+def rp_rmse_choose_scale(rp_model, rp_obs, scale_bounds=[0, 1], grouping_var='country'):
+    rp = merge_outputs_and_obs(rp_model, rp_obs, grouping_var)
     assert not np.any(pd.isna(rp['model']))  # There should at least be modelled zero values for every country
 
     # now we do some sneaky math


### PR DESCRIPTION
@MarcelSerina this is FYI
The code will be merged into the (ever larger) calibration_module



Methods within the calibration module's cost function calculations do operations to align modelled return period impacts to observed return period impacts, performing interpolations and merges.

Until now they always assumed their input data was at a country-return period resolution, and operations were grouped by the 'country' column.

This is no longer the case: sometimes we want to group by different geographies when calculating costs (regional groups, or vulnerability categories) and sometimes we don't want to group at all.

This updates the two relevant methods, adding a grouping_var parameter and setting its default value to 'country' for backward compatibility.