### PR TITLE
.new(pipeline): added JRC river functions for agriculture

### DIFF
--- a/nccs/analysis.py
+++ b/nccs/analysis.py
@@ -650,6 +650,6 @@ if __name__ == "__main__":
     # from run_configurations.config import CONFIG
 
     # This is for testing
-    from run_configurations.test_config import CONFIG  # change here to test_config if needed
+    from run_configurations.test_config import CONFIG2  # change here to test_config if needed
 
-    run_pipeline_from_config(CONFIG)
+    run_pipeline_from_config(CONFIG2)

--- a/nccs/dashboard.py
+++ b/nccs/dashboard.py
@@ -24,9 +24,9 @@ logging.getLogger().setLevel(logging.INFO)
 
 dotenv.load_dotenv()
 """
-To run the dashboard.py 
+To run the nccs\dashboard.py 
 first: run the the terminal the following command: python dashboard.py
-next: bokeh serve dashboard.py --show
+next: bokeh serve nccs\dashboard.py --show
 """
 
 
@@ -479,4 +479,4 @@ lt = layout(
 )
 curdoc().add_root(lt)
 curdoc().title = "NCCS - Dashboard"
-print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")
+print("Done!\nTo show the Dashboard run:\nbokeh serve nccs\dashboard.py --show")

--- a/nccs/pipeline/direct/agriculture.py
+++ b/nccs/pipeline/direct/agriculture.py
@@ -1,10 +1,12 @@
 import typing
 
 import numpy as np
+import pandas as pd
 from climada.entity import ImpactFunc
 from climada.entity import ImpactFuncSet
 from climada.util.api_client import Client
 from climada_petals.entity.impact_funcs.relative_cropyield import ImpfRelativeCropyield
+from climada_petals.entity.impact_funcs.river_flood import RIVER_FLOOD_REGIONS_CSV
 from pycountry import countries
 
 CropType = typing.Literal[
@@ -67,6 +69,109 @@ def get_impf_set_tc():
     imp_fun_maize.check()
     imp_fun_set = ImpactFuncSet([imp_fun_maize])
     return imp_fun_set
+
+
+
+def get_impf_set_rf(country_iso3alpha):
+    """
+    New Impact function set for river flood and agriculture for specified region in the world
+
+    Based on the JRC publication: https://publications.jrc.ec.europa.eu/repository/handle/JRC105688
+
+    Regional functions available for Africa, Europe, North America, and Asia
+
+    Other regions (Oceania and South America will get the Global function assigned)
+
+    In this study the damage fractions in the damage curves are intended to span from zero
+    (no damage) to one (maximum damage).
+
+    For agriculture the damage is related to a loss in output when the yield is destroyed by floods.
+
+
+
+    """
+
+    # Use the flood module's lookup to get the regional impact function for the country
+    country_info = pd.read_csv(RIVER_FLOOD_REGIONS_CSV)
+    impf_id = country_info.loc[country_info['ISO'] == country_iso3alpha, 'impf_RF'].values[0]
+
+    if impf_id == 1:
+        impf_jrc_africa = ImpactFunc(
+            id = 1,
+            name = "Flood Africa JRC Agriculture",
+            intensity_unit="m",
+            haz_type="RF",
+            intensity = np.array([0, 0.5, 1, 1.5, 2, 3, 4, 5, 6]),
+            mdd = np.array([0.00, 0.24, 0.47, 0.74, 0.92, 1.00, 1.00,
+                            1.00, 1.00]),
+            paa = np.array([1, 1, 1, 1, 1, 1, 1,
+                            1, 1])
+        )
+        impf_jrc_africa.check()
+        imp_fun_set = ImpactFuncSet([impf_jrc_africa])
+
+    elif impf_id == 2:
+        impf_jrc_asia = ImpactFunc(
+            id = 1,
+            name = "Flood Asia JRC Agriculture",
+            intensity_unit="m",
+            haz_type="RF",
+            intensity = np.array([0, 0.5, 1, 1.5, 2, 3, 4, 5, 6]),
+            mdd = np.array([0.00, 0.14, 0.37, 0.52, 0.56, 0.66, 0.83,
+                            0.99, 1.00]),
+            paa = np.array([1, 1, 1, 1, 1, 1, 1,
+                            1, 1])
+        )
+        impf_jrc_asia.check()
+        imp_fun_set = ImpactFuncSet([impf_jrc_asia])
+
+    elif impf_id == 3:
+        impf_jrc_europe = ImpactFunc(
+            id = 1,
+            name = "Flood Europe JRC Agriculture",
+            intensity_unit="m",
+            haz_type="RF",
+            intensity = np.array([0, 0.5, 1, 1.5, 2, 3, 4, 5, 6]),
+            mdd = np.array([0.00, 0.30, 0.55, 0.65, 0.75, 0.85, 0.95,
+                            1.00, 1.00]),
+            paa = np.array([1, 1, 1, 1, 1, 1, 1,
+                            1, 1])
+        )
+        impf_jrc_europe.check()
+        imp_fun_set = ImpactFuncSet([impf_jrc_europe])
+
+    elif impf_id == 4:
+        impf_jrc_northamerica = ImpactFunc(
+            id = 1,
+            name = "Flood North America JRC Agriculture",
+            intensity_unit="m",
+            haz_type="RF",
+            intensity = np.array([0, 0.5, 1, 1.5, 2, 3, 4, 5, 6]),
+            mdd = np.array([0.02, 0.27, 0.47, 0.55, 0.60, 0.76, 0.87,
+                            0.95, 1.00]),
+            paa = np.array([1, 1, 1, 1, 1, 1, 1,
+                            1, 1])
+        )
+        impf_jrc_northamerica.check()
+        imp_fun_set = ImpactFuncSet([impf_jrc_northamerica])
+    else:
+        impf_jrc_global = ImpactFunc(
+            id=1,
+            name = "Flood Global JRC Agriculture",
+            intensity_unit="m",
+            haz_type="RF",
+            intensity = np.array([0, 0.5, 1, 1.5, 2, 3, 4, 5, 6]),
+            mdd = np.array([0.00, 0.24, 0.47, 0.62, 0.71, 0.82, 0.91,
+                            0.99, 1.00]),
+            paa = np.array([1, 1, 1, 1, 1, 1, 1,
+                            1, 1])
+        )
+        impf_jrc_global.check()
+        imp_fun_set = ImpactFuncSet([impf_jrc_global])
+
+    return imp_fun_set
+
+
 
 
 def get_hazard(

--- a/nccs/pipeline/direct/direct.py
+++ b/nccs/pipeline/direct/direct.py
@@ -251,6 +251,8 @@ def apply_sector_impf_set(
         return agriculture.get_impf_set_tc()
     if hazard == 'tropical_cyclone':
         return ImpactFuncSet([get_sector_impf_tc(country_iso3alpha, sector_bi, calibrated, use_sector_bi_scaling)])
+    if hazard == 'river_flood' and sector == 'agriculture':
+        return agriculture.get_impf_set_rf(country_iso3alpha)
     if hazard == 'river_flood':
         return ImpactFuncSet([get_sector_impf_rf(country_iso3alpha, sector_bi, use_sector_bi_scaling)])
     if hazard == 'wildfire':

--- a/nccs/run_configurations/test_config.py
+++ b/nccs/run_configurations/test_config.py
@@ -45,7 +45,7 @@ CONFIG = {
 }
 
 CONFIG2 = {
-    "run_title": "test_run_MEX_region",
+    "run_title": "test_run_agri_fun",
     "n_sim_years": 300,                 # Number of stochastic years of supply chain impacts to simulate
     "io_approach": ["ghosh"],           # Supply chain IO to use. One or more of "leontief", "ghosh"
     "force_recalculation": False,       # If an intermediate file or output already exists should it be recalculated?
@@ -71,8 +71,8 @@ CONFIG2 = {
     "runs": [
         {
             "hazard": "river_flood",
-            "sectors": ["manufacturing"],
-            "countries": ['Mexico'],
+            "sectors": ["agriculture"],
+            "countries": ['Nigeria', 'United States', 'Germany', 'China', 'Australia'],
             "scenario_years": [
                 {"scenario": "None", "ref_year": "historical"},
             ]


### PR DESCRIPTION
This PR contains the discussed impact functions for river flood impacts on agriculture for different regions based on the JRC publication: 

https://publications.jrc.ec.europa.eu/repository/handle/JRC105688

It contains new functions for Europe, Asia, North America, Africa, and for the remaining regions a global one. 

It follows a similar logic that the previous RF functions using the regional mapping of the countries from this module

I tested it for one country within a region and it seems to work

@ChrisFairless One thing I was not sure about is the ID within each region's definition to be 1 everywhere. If I give each function a new ID, it will raise an error. Since they get added to the set each time, I think this is the way to go. 

Let me know if it looks good and you can merge it. 