### PR TITLE
Sea level rise pipeline

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -24,9 +24,9 @@ logging.getLogger().setLevel(logging.INFO)
 
 dotenv.load_dotenv()
 """
-To run the nccs\dashboard.py 
+To run the dashboard.py 
 first: run the the terminal the following command: python dashboard.py
-next: bokeh serve nccs\dashboard.py --show
+next: bokeh serve dashboard.py --show
 """
 
 
@@ -479,4 +479,4 @@ lt = layout(
 )
 curdoc().add_root(lt)
 curdoc().title = "NCCS - Dashboard"
-print("Done!\nTo show the Dashboard run:\nbokeh serve nccs\dashboard.py --show")
+print("Done!\nTo show the Dashboard run:\nbokeh serve dashboard.py --show")

--- a/exposures/forestry/refinement_1/README_forestry.md
+++ b/exposures/forestry/refinement_1/README_forestry.md
@@ -6,6 +6,14 @@
 Map: https://cds.climate.copernicus.eu/cdsapp#!/dataset/10.24381/cds.006f2c9a?tab=overview
 Description: Global map describing the land surface into 22 classes
 
+License and Attribution:
+
+ESA CCI Land Cover licence Terms of use: The products are made available to the public by ESA and the consortium. You may use one or several CCI-LC products land cover map for educational and/or scientific purposes, without any fee on the condition that you credit the ESA Climate Change Initiative and in particular its Land Cover project as the source of the CCI-LC database. Should you write any scientific publication on the results of research activities that use one or several CCI-LC products as input, you shall acknowledge the ESA CCI Land Cover project in the text of the publication and provide the project with an electronic copy of the publication (contact@esa-landcover-cci.org). If you wish to use one or several CCI-LC products in advertising or in any commercial promotion, you shall acknowledge the ESA CCI Land Cover project and you must submit the layout to the project for approval beforehand (contact@esa-landcover-cci.org).
+
+Copyright notice: \© ESA Climate Change Initiative - Land Cover led by UCLouvain (2017)
+
+Copernicus Climate Change Service, Climate Data Store, (2019): Land cover classification gridded maps from 1992 to present derived from satellite observation. Copernicus Climate Change Service (C3S) Climate Data Store (CDS). DOI: 10.24381/cds.006f2c9a (Accessed 2024)
+
 **2. Raw file name:** "C3S-LC-L4-LCCS-Map-300m-P1Y-2020-v2.1.1.nc"
 
 **3. Time selection:** 2020-01-01

--- a/exposures/manufacturing/manufacturing_general_exposure/refinement_1/Step1_EDGAR_convert_txt_to_dataframe.py
+++ b/exposures/manufacturing/manufacturing_general_exposure/refinement_1/Step1_EDGAR_convert_txt_to_dataframe.py
@@ -9,8 +9,7 @@ project_root = root_dir()
 
 
 """
-The hdf5 also needs a package called tables, which is why it is best to also run this code in the
-virtual environment .venv (Python 3.10 (nccs-correntics)
+The hdf5 also needs a package called tables
 
 
 Additionally, had to remove the two top lines within the header of the txt file of the raw data

--- a/exposures/manufacturing/manufacturing_general_exposure/refinement_1/Step3_EDGAR_assign_value.py
+++ b/exposures/manufacturing/manufacturing_general_exposure/refinement_1/Step3_EDGAR_assign_value.py
@@ -56,7 +56,7 @@ def get_manufacturing_exp(data,
 
 
         try:
-            # For countries that are explicitely in the MRIO  table:
+            # For countries that are explicitly in the MRIO  table:
             cnt_df['value'] = cnt_df['normalized_emissions'] * (
                 glob_prod.loc[iso3_cnt].loc[repr_sectors].sum().values[0])
         except KeyError:

--- a/exposures/manufacturing/manufacturing_general_exposure/refinement_1/Step3_alt_assign_value_non_linear.py
+++ b/exposures/manufacturing/manufacturing_general_exposure/refinement_1/Step3_alt_assign_value_non_linear.py
@@ -20,7 +20,7 @@ worldmap = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
 
 """
 Important Note, when running the script with a new version or modifications, make sure to delete teh files on the s3 bucket
-or that they are properly replace. Goal to onyl have the relevant files on the s3 bucket and no duplicates
+or that they are properly replace. Goal to only have the relevant files on the s3 bucket and no duplicates
 """
 
 
@@ -186,7 +186,7 @@ exp = get_manufacturing_exp(data=data,
                             )
 
 """
-Saving of file, first, locally and secondly also to the s3 Bukcet
+Saving of file, first, locally and secondly also to the s3 bucket
 """
 
 # # Save a shape file to check it in QGIS

--- a/nccs/pipeline/direct/agriculture.py
+++ b/nccs/pipeline/direct/agriculture.py
@@ -72,7 +72,7 @@ def get_impf_set_tc():
 
 
 
-def get_impf_set_rf(country_iso3alpha):
+def get_impf_set_rf(country_iso3alpha, haz_type="RF"):
     """
     New Impact function set for river flood and agriculture for specified region in the world
 
@@ -96,81 +96,78 @@ def get_impf_set_rf(country_iso3alpha):
     impf_id = country_info.loc[country_info['ISO'] == country_iso3alpha, 'impf_RF'].values[0]
 
     if impf_id == 1:
-        impf_jrc_africa = ImpactFunc(
+        impf = ImpactFunc(
             id = 1,
             name = "Flood Africa JRC Agriculture",
             intensity_unit="m",
-            haz_type="RF",
+            haz_type=haz_type,
             intensity = np.array([0, 0.5, 1, 1.5, 2, 3, 4, 5, 6]),
             mdd = np.array([0.00, 0.24, 0.47, 0.74, 0.92, 1.00, 1.00,
                             1.00, 1.00]),
             paa = np.array([1, 1, 1, 1, 1, 1, 1,
                             1, 1])
         )
-        impf_jrc_africa.check()
-        imp_fun_set = ImpactFuncSet([impf_jrc_africa])
+
 
     elif impf_id == 2:
-        impf_jrc_asia = ImpactFunc(
+        impf = ImpactFunc(
             id = 1,
             name = "Flood Asia JRC Agriculture",
             intensity_unit="m",
-            haz_type="RF",
+            haz_type=haz_type,
             intensity = np.array([0, 0.5, 1, 1.5, 2, 3, 4, 5, 6]),
             mdd = np.array([0.00, 0.14, 0.37, 0.52, 0.56, 0.66, 0.83,
                             0.99, 1.00]),
             paa = np.array([1, 1, 1, 1, 1, 1, 1,
                             1, 1])
         )
-        impf_jrc_asia.check()
-        imp_fun_set = ImpactFuncSet([impf_jrc_asia])
+
+
 
     elif impf_id == 3:
-        impf_jrc_europe = ImpactFunc(
+        impf = ImpactFunc(
             id = 1,
             name = "Flood Europe JRC Agriculture",
             intensity_unit="m",
-            haz_type="RF",
+            haz_type=haz_type,
             intensity = np.array([0, 0.5, 1, 1.5, 2, 3, 4, 5, 6]),
             mdd = np.array([0.00, 0.30, 0.55, 0.65, 0.75, 0.85, 0.95,
                             1.00, 1.00]),
             paa = np.array([1, 1, 1, 1, 1, 1, 1,
                             1, 1])
         )
-        impf_jrc_europe.check()
-        imp_fun_set = ImpactFuncSet([impf_jrc_europe])
+
 
     elif impf_id == 4:
-        impf_jrc_northamerica = ImpactFunc(
+        impf = ImpactFunc(
             id = 1,
             name = "Flood North America JRC Agriculture",
             intensity_unit="m",
-            haz_type="RF",
+            haz_type=haz_type,
             intensity = np.array([0, 0.01, 0.5, 1, 1.5, 2, 3, 4, 5, 6]),
             mdd = np.array([0, 0.02, 0.27, 0.47, 0.55, 0.60, 0.76, 0.87,
                             0.95, 1.00]),
             paa = np.array([1, 1, 1, 1, 1, 1, 1, 1,
                             1, 1])
         )
-        impf_jrc_northamerica.check()
-        imp_fun_set = ImpactFuncSet([impf_jrc_northamerica])
+
     else:
-        impf_jrc_global = ImpactFunc(
+        impf = ImpactFunc(
             id=1,
             name = "Flood Global JRC Agriculture",
             intensity_unit="m",
-            haz_type="RF",
+            haz_type=haz_type,
             intensity = np.array([0, 0.5, 1, 1.5, 2, 3, 4, 5, 6]),
             mdd = np.array([0.00, 0.24, 0.47, 0.62, 0.71, 0.82, 0.91,
                             0.99, 1.00]),
             paa = np.array([1, 1, 1, 1, 1, 1, 1,
                             1, 1])
         )
-        impf_jrc_global.check()
-        imp_fun_set = ImpactFuncSet([impf_jrc_global])
 
-    return imp_fun_set
 
+    impf.check()
+
+    return ImpactFuncSet([impf])
 
 
 

--- a/nccs/pipeline/direct/direct.py
+++ b/nccs/pipeline/direct/direct.py
@@ -424,6 +424,31 @@ def get_hazard(haz_type, country_iso3alpha, scenario, ref_year):
         )
         return haz
 
+    elif haz_type == 'sea_level_rise':
+        """
+        Sea level rise has the following file configurations:
+        
+        "future climate" includes changes also to the TC surge
+                
+        - historical climate, no SLR: tc_surge/no_cc/no_slr/
+        - future climate, no SLR:
+            tc_surge/rcp26_2060/no_slr/
+            tc_surge/rcp85_2060/no_slr/
+         
+        -historical climate, future SLR: 
+            tc_surge/no_cc/ssp126_2060slr/
+            tc_surge/no_cc/sspssp585_2060slr/
+        future climate, future SLR:
+            tc_surge/rcp26_2060/ssp126_2060slr/
+            tc_surge/rcp26_2060/ssp585_2060slr/
+        """
+        if scenario == 'None' and ref_year == 'historical':
+            s3_path = f'hazard/tc_surge/no_cc/no_slr/surge_28arcsec_25synth_{country_iso3alpha}_nossp_noslr_no_cc.hdf5'
+        else:
+            s3_path = (f'hazard/tc_surge/{scenario}_{ref_year}/surge_28arcsec_25synth_{country_iso3alpha}'
+                       f'_{scenario}_{ref_year}_no_cc.hdf5')
+        return download_hazard_from_s3(s3_path)
+
     elif haz_type.startswith("relative_crop_yield"):
         _, crop_type = agriculture.split_agriculture_hazard(haz_type)
         # TODO currently always returns the same hazard

--- a/nccs/run_configurations/config_sea_level.py
+++ b/nccs/run_configurations/config_sea_level.py
@@ -1,0 +1,86 @@
+"""
+This file contains the full run of the pipeline.
+"""
+import pathos as pa
+ncpus = 3
+ncpus = pa.helpers.cpu_count() - 1
+
+
+CONFIG = {
+    "run_title": "mvp_sea_level",
+    "n_sim_years": 300,                     # Number of stochastic years of supply chain impacts to simulate
+    "io_approach": ["ghosh", "leontief"],   # Supply chain IO to use. One or more of "leontief", "ghosh"
+    "force_recalculation": False,           # If an intermediate file or output already exists should it be recalculated?
+    "use_s3": False,                        # Also load and save data from an S3 bucket
+    "log_level": "INFO",
+    "seed": 161,
+
+    # Which parts of the model chain to run:
+    "do_direct": True,                      # Calculate direct impacts (that aren't already calculated)
+    "do_yearsets": True,                    # Calculate direct impact yearsets (that aren't already calculated)
+    "do_multihazard": False,                # Also combine hazards to create multi-hazard supply chain shocks
+    "do_indirect": True,                    # Calculate any indirect supply chain impacts (that aren't already calculated)
+    "use_sector_bi_scaling": True,           # Calculate sectoral business interruption scaling
+
+    # Impact functions:
+    "business_interruption": True,          # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducibility
+    "calibrated": True,                     # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducibility
+
+    # Parallisation:
+    "do_parallel": False,  # Parallelise some operations
+    "ncpus": ncpus,
+
+    "runs": [
+        {
+            "hazard": "sea_level_rise",
+            "sectors": ["agriculture", "forestry", "mining", "manufacturing", "service", "energy", "water", "waste",
+                        "basic_metals", "pharmaceutical", "food", "wood", "chemical", "rubber_and_plastic",
+                        "non_metallic_mineral", "refin_and_transform"],
+            "countries": ['Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Antigua and Barbuda', 'Argentina',
+                          'Armenia', 'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh',
+                          'Barbados',
+                          'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia, Plurinational State of',
+                          'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei Darussalam', 'Bulgaria',
+                          'Burkina Faso',
+                          'Burundi', 'Cabo Verde', 'Cambodia', 'Cameroon',
+                          'Canada', 'Central African Republic', 'Chad', 'Chile', 'China', 'Colombia', 'Comoros',
+                          'Congo',
+                          'Congo, The Democratic Republic of the', 'Costa Rica', 'Croatia', "Côte d'Ivoire",
+                          'Cuba', 'Cyprus', 'Czechia', 'Denmark', 'Djibouti', 'Dominica', 'Dominican Republic',
+                          'Timor-Leste', 'Ecuador', 'Egypt', 'El Salvador', 'Equatorial Guinea', 'Eritrea',
+                          'Estonia', 'Eswatini', 'Ethiopia', 'Fiji', 'Finland', 'France', 'Gabon', 'Gambia', 'Georgia',
+                          'Germany', 'Ghana', 'Greece', 'Grenada', 'Guatemala', 'Guinea', 'Guinea-Bissau', 'Guyana',
+                          'Haiti', 'Honduras', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran, Islamic Republic of', 'Iraq',
+                          'Ireland', 'Israel', 'Italy', 'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kiribati',
+                          "Korea, Democratic People's Republic of",
+                          'Korea, Republic of', 'Kuwait', 'Kyrgyzstan', "Lao People's Democratic Republic", 'Latvia',
+                          'Lebanon', 'Lesotho', 'Liberia',
+                          'Libya', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Madagascar', 'Malawi', 'Malaysia',
+                          'Maldives', 'Mali', 'Malta', 'Marshall Islands', 'Mauritania', 'Mauritius',
+                          'Mexico', 'Micronesia, Federated States of', 'Moldova, Republic of', 'Monaco', 'Mongolia',
+                          'Morocco', 'Mozambique', 'Myanmar', 'Namibia', 'Nauru', 'Nepal', 'Netherlands',
+                          'New Zealand', 'Nicaragua', 'Niger', 'Nigeria', 'North Macedonia', 'Norway', 'Oman',
+                          'Pakistan',
+                          'Palau', 'Panama', 'Papua New Guinea', 'Paraguay', 'Peru', 'Philippines', 'Poland',
+                          'Portugal',
+                          'Qatar', 'Romania', 'Russian Federation', 'Rwanda', 'Saint Kitts and Nevis', 'Saint Lucia',
+                          'Saint Vincent and the Grenadines', 'Samoa', 'San Marino', 'Sao Tome and Principe',
+                          'Saudi Arabia',
+                          'Senegal', 'Seychelles', 'Sierra Leone', 'Singapore', 'Slovakia', 'Slovenia',
+                          'Solomon Islands', 'Somalia', 'South Africa', 'Spain', 'Sri Lanka', 'Sudan',
+                          'Suriname', 'Sweden', 'Syrian Arab Republic', 'Taiwan, Province of China',
+                          'Tajikistan', 'Tanzania, United Republic of', 'Thailand',
+                          'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan', 'Tuvalu',
+                          'Uganda',
+                          'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay', 'Uzbekistan',
+                          'Vanuatu', 'Venezuela, Bolivarian Republic of', 'Viet Nam', 'Yemen', 'Zambia',
+                          'Zimbabwe'],
+            "scenario_years": [
+                {"scenario": "None", "ref_year": "historical"},
+                {"scenario": "ssp126", "ref_year": 2060},
+                {"scenario": "ssp585", "ref_year": 2060},
+
+            ]
+        }
+    ]
+}

--- a/nccs/run_configurations/test_config.py
+++ b/nccs/run_configurations/test_config.py
@@ -221,7 +221,7 @@ CONFIG6 = {
             "countries": ['Netherlands'],
             "scenario_years": [
                 {"scenario": "None", "ref_year": "historical"},
-                # {"scenario": "ssp126", "ref_year": 2060},
+                {"scenario": "ssp126", "ref_year": 2060},
                 # {"scenario": "ssp585", "ref_year": 2060},
             ]
         }

--- a/nccs/run_configurations/test_config.py
+++ b/nccs/run_configurations/test_config.py
@@ -189,3 +189,41 @@ CONFIG5 = {
         },
     ]
 }
+
+CONFIG6 = {
+    "run_title": "test_sea",
+    "n_sim_years": 300,                 # Number of stochastic years of supply chain impacts to simulate
+    "io_approach": ["ghosh"],           # Supply chain IO to use. One or more of "leontief", "ghosh"
+    "force_recalculation": False,       # If an intermediate file or output already exists should it be recalculated?
+    "use_s3": False,                    # Also load and save data from an S3 bucket
+    "log_level": "INFO",
+    "seed": 161,
+
+    # Which parts of the model chain to run:
+    "do_direct": True,                  # Calculate direct impacts (that aren't already calculated)
+    "do_yearsets": True,                # Calculate direct impact yearsets (that aren't already calculated)
+    "do_multihazard": False,            # Also combine hazards to create multi-hazard supply chain shocks
+    "do_indirect": True,                # Calculate any indirect supply chain impacts (that aren't already calculated)
+    "use_sector_bi_scaling": True,     # Calculate sectoral business interruption scaling
+
+    # Impact functions:
+    "business_interruption": True,      # Turn off to assume % asset loss = % production loss. Mostly for debugging and reproducibility
+    "calibrated": True,                 # Turn off to use best guesstimate impact functions. Mostly for debugging and reproducibility
+
+    # Parallisation:
+    "do_parallel": False,                # Parallelise some operations
+    "ncpus": ncpus,
+
+    "runs": [
+        {
+            "hazard": "sea_level_rise",
+            "sectors": ["agriculture"],
+            "countries": ['Netherlands'],
+            "scenario_years": [
+                {"scenario": "None", "ref_year": "historical"},
+                # {"scenario": "ssp126", "ref_year": 2060},
+                # {"scenario": "ssp585", "ref_year": 2060},
+            ]
+        }
+    ]
+}

--- a/nccs/run_configurations/test_config.py
+++ b/nccs/run_configurations/test_config.py
@@ -222,7 +222,7 @@ CONFIG6 = {
             "scenario_years": [
                 {"scenario": "None", "ref_year": "historical"},
                 {"scenario": "ssp126", "ref_year": 2060},
-                # {"scenario": "ssp585", "ref_year": 2060},
+                {"scenario": "ssp585", "ref_year": 2060},
             ]
         }
     ]

--- a/nccs/sea_level_rise_difference.py
+++ b/nccs/sea_level_rise_difference.py
@@ -5,8 +5,11 @@ from nccs.utils.folder_naming import get_indirect_output_dir, get_direct_output_
 """
 Generates a difference between the baseline and the future steps of sea level rise
 
-Uses the the raw ouput of the pipeline and calculates the difference of the impact between the 
+Uses the the raw output of the pipeline and calculates the difference of the impact between the 
 baseline and the future scenario
+
+The order is future minus past, so positive values should show and increase of the impact in the future and negative 
+values should indicate less impact in the future
 
 """
 
@@ -16,8 +19,8 @@ import pandas as pd
 RUN_TITLE = "test_sea"
 
 # Paths to the folder containing the CSV files and the output folder
-input_folder = f"{get_indirect_output_dir(RUN_TITLE)}"  # Replace with the directory containing your CSV files
-output_folder = f"{get_indirect_output_dir(RUN_TITLE)}/sea-level-difference"   # Replace with the directory where you want to save outputs
+input_folder = f"{get_indirect_output_dir(RUN_TITLE)}"
+output_folder = f"{get_indirect_output_dir(RUN_TITLE)}/sea-level-difference"
 columns_to_diff = ["imaxPL", "irmaxPL", "iAAPL", "irAAPL", "iPL100", "irPL100"]
 
 
@@ -41,7 +44,7 @@ def parse_filename(filename):
         "scenario": parts[6],
         "year": parts[7],
         "methodology": parts[8],
-        "country": parts[9].split('.')[0],  # Remove file extension
+        "country": parts[9].split('.')[0],
     }
 
 def calculate_differences(file1, file2, columns_to_diff, output_path, historical_file, future_scenario):

--- a/nccs/sea_level_rise_difference.py
+++ b/nccs/sea_level_rise_difference.py
@@ -1,0 +1,121 @@
+import glob
+import pandas as pd
+from nccs.utils.folder_naming import get_indirect_output_dir, get_direct_output_dir
+
+"""
+Generates a difference between the baseline and the future steps of sea level rise
+
+Uses the the raw ouput of the pipeline and calculates the difference of the impact between the 
+baseline and the future scenario
+
+"""
+
+import os
+import pandas as pd
+
+RUN_TITLE = "test_sea"
+
+# Paths to the folder containing the CSV files and the output folder
+input_folder = f"{get_indirect_output_dir(RUN_TITLE)}"  # Replace with the directory containing your CSV files
+output_folder = f"{get_indirect_output_dir(RUN_TITLE)}/sea-level-difference"   # Replace with the directory where you want to save outputs
+columns_to_diff = ["imaxPL", "irmaxPL", "iAAPL", "irAAPL", "iPL100", "irPL100"]
+
+
+# Ensure the output folder exists
+os.makedirs(output_folder, exist_ok=True)
+
+def parse_filename(filename):
+    """
+    Parse the filename into its components: sector, scenario, year, methodology, country
+    Assumes filenames follow this structure:
+    indirect_impacts_sea_level_rise_<hazard>_<sector>_<scenario>_<year>_<methodology>_<country>.csv
+    """
+    parts = filename.split('_')
+    if len(parts) < 7 or not filename.startswith("indirect_impacts_sea_level_rise"):
+        return None  # Skip files that don't follow the expected structure or don't match the prefix
+
+    return {
+        "prefix": "indirect_impacts",  # Keep the full prefix as part of the filename structure
+        "hazard": "sea_level_rise",
+        "sector": parts[5],
+        "scenario": parts[6],
+        "year": parts[7],
+        "methodology": parts[8],
+        "country": parts[9].split('.')[0],  # Remove file extension
+    }
+
+def calculate_differences(file1, file2, columns_to_diff, output_path, historical_file, future_scenario):
+    """
+    Calculate the differences between two CSV files and save the result.
+    """
+    df1 = pd.read_csv(file1)
+    df2 = pd.read_csv(file2)
+
+    # Ensure both DataFrames have the same structure
+    if not all(df1.columns == df2.columns):
+        print(f"Skipping: Files {file1} and {file2} have mismatched columns.")
+        return
+
+    # Calculate differences
+    diff_df = df1.copy()
+    for col in columns_to_diff:
+        if col in df1 and col in df2:
+            diff_df[col] = df2[col] - df1[col]  # file2 - file1 (future minus past)
+
+    # Modify the "scenario" and "ref_year" columns
+    scenario_label = f"{historical_file['year']}_vs_{future_scenario}_2060"
+    diff_df["scenario"] = scenario_label
+    diff_df["ref_year"] = scenario_label
+
+    # Save the result
+    diff_df.to_csv(output_path, index=False)
+    print(f"Saved difference to {output_path}")
+
+def process_files(input_folder, columns_to_diff, output_folder):
+    """
+    Main function to process the files, calculate differences, and save the results.
+    """
+    # Read all files in the folder that start with the correct prefix
+    files = [f for f in os.listdir(input_folder) if
+             f.lower().endswith('.csv') and f.startswith("indirect_impacts_sea_level_rise")]
+
+    # Group the files by methodology, sector, and country
+    file_groups = {}
+    for file in files:
+        metadata = parse_filename(file)
+        if metadata:
+            key = (metadata["methodology"], metadata["sector"], metadata["country"])
+            if key not in file_groups:
+                file_groups[key] = []
+            file_groups[key].append(metadata)
+
+    # Process each group
+    for key, group_files in file_groups.items():
+        methodology, sector, country = key
+
+        # Separate the files into historical and future scenario files
+        historical_file = next((f for f in group_files if f["year"] == "historical"), None)
+        future_ssp126_file = next((f for f in group_files if f["scenario"] == "ssp126" and f["year"] == "2060"), None)
+        future_ssp585_file = next((f for f in group_files if f["scenario"] == "ssp585" and f["year"] == "2060"), None)
+
+        # If there are no historical or future files, skip this group
+        if not historical_file or not future_ssp126_file or not future_ssp585_file:
+            continue
+
+        # Get the path to the historical and future files
+        historical_path = os.path.join(input_folder, f"{'_'.join(historical_file.values())}.csv")
+        future_ssp126_path = os.path.join(input_folder, f"{'_'.join(future_ssp126_file.values())}.csv")
+        future_ssp585_path = os.path.join(input_folder, f"{'_'.join(future_ssp585_file.values())}.csv")
+
+        # Create the output filenames and paths
+        output_filename_ssp126 = f"diff_{country}_{sector}_{methodology}_{historical_file['year']}_vs_ssp126_2060.csv"
+        output_filename_ssp585 = f"diff_{country}_{sector}_{methodology}_{historical_file['year']}_vs_ssp585_2060.csv"
+        output_path_ssp126 = os.path.join(output_folder, output_filename_ssp126)
+        output_path_ssp585 = os.path.join(output_folder, output_filename_ssp585)
+
+        # Calculate and save the differences for both scenarios
+        calculate_differences(historical_path, future_ssp126_path, columns_to_diff, output_path_ssp126, historical_file, "ssp126")
+        calculate_differences(historical_path, future_ssp585_path, columns_to_diff, output_path_ssp585, historical_file, "ssp585")
+
+
+process_files(input_folder, columns_to_diff, output_folder)


### PR DESCRIPTION
This PR contains the integration of the sea level rise hazard into the pipeline

**get hazard from s3 bucket:** 
- currently, we use the following files:
- historical climate, no SLR: 
            tc_surge/no_cc/no_slr/
- historical climate, future SLR: 
            tc_surge/no_cc/ssp126_2060slr/
            tc_surge/no_cc/ssp585_2060slr/

**Config**
- contains a new config file to run the sea level hazard: nccs/run_configurations/config_sea_level.py

**Calculate change between baseline and future**
- there is a separate script that needs to be executed after the sea level pipeline run and the csv flies are created
- run name needs to be indicated
- it is called: nccs/sea_level_rise_difference.py
- It creates a new folder in the indirect path of the run where for each country, sector, and io approach two files get produced: Historical vs ssp126 2060 and historical vs ssp585 2060
- Future minus historical --> Positive values indicate more impact in the future, negative values, less impact in the future

