### PR TITLE
Yearsets bugfix

### DIFF
--- a/nccs/analysis.py
+++ b/nccs/analysis.py
@@ -474,7 +474,6 @@ def df_create_combined_hazard_yearsets_agriculture(
 def create_single_yearset(
         analysis_spec: pd.DataFrame,
         n_sim_years: int,
-        poisson: bool,
         seed: int,
 ):
     """Take the metadata for an analysis and create an impact yearset if it 
@@ -487,10 +486,6 @@ def create_single_yearset(
         A row of a dataframe created by config_to_dataframe
     n_sim_years : int
         Number of years to create for each output yearset
-    poisson: bool
-        Treat the sampling as a poisson process (the number of events in a year 
-        is a random variable), or not (there is one event per year, sampled from
-        the event set).
     seed : int
         The random number seed to use in each yearset's sampling
     """
@@ -498,7 +493,7 @@ def create_single_yearset(
     imp = get_impact_from_file(row['direct_impact_path'])
 
     poisson_hazards = ['tropical_cyclone']
-    poisson = row['haz_type'] in poisson_hazards
+    poisson = row['hazard'] in poisson_hazards
 
     # TODO we don't actually want to generate a yearset if we're looking at observed events
     imp_yearset = yearset_from_imp(

--- a/nccs/analysis.py
+++ b/nccs/analysis.py
@@ -474,6 +474,7 @@ def df_create_combined_hazard_yearsets_agriculture(
 def create_single_yearset(
         analysis_spec: pd.DataFrame,
         n_sim_years: int,
+        poisson: bool,
         seed: int,
 ):
     """Take the metadata for an analysis and create an impact yearset if it 
@@ -486,17 +487,24 @@ def create_single_yearset(
         A row of a dataframe created by config_to_dataframe
     n_sim_years : int
         Number of years to create for each output yearset
+    poisson: bool
+        Treat the sampling as a poisson process (the number of events in a year 
+        is a random variable), or not (there is one event per year, sampled from
+        the event set).
     seed : int
         The random number seed to use in each yearset's sampling
     """
-
     row = analysis_spec.copy().to_dict()
     imp = get_impact_from_file(row['direct_impact_path'])
+
+    poisson_hazards = ['tropical_cyclone']
+    poisson = row['haz_type'] in poisson_hazards
 
     # TODO we don't actually want to generate a yearset if we're looking at observed events
     imp_yearset = yearset_from_imp(
         imp,
         n_sim_years,
+        poisson=poisson,
         cap_exposure=get_sector_exposure(row['sector'], row['country']),
         seed=seed
     )

--- a/nccs/pipeline/direct/calc_yearset.py
+++ b/nccs/pipeline/direct/calc_yearset.py
@@ -1,5 +1,6 @@
 import numpy as np
 import copy
+import logging
 from scipy import sparse
 from functools import reduce
 
@@ -51,6 +52,7 @@ def sample_from_poisson(n_sampled_years, lam, seed=None):
 
 
 yearsets.sample_from_poisson = sample_from_poisson
+LOGGER = logging.getLogger(__name__)
 
 
 def yearset_from_imp(imp, n_sim_years, poisson=True, cap_exposure=None, seed=None):

--- a/nccs/pipeline/direct/direct.py
+++ b/nccs/pipeline/direct/direct.py
@@ -258,7 +258,7 @@ def apply_sector_impf_set(
     if hazard == 'wildfire':
         return ImpactFuncSet([get_sector_impf_wf(sector_bi, use_sector_bi_scaling)])
     if hazard == 'storm_europe':
-        return ImpactFuncSet([get_sector_impf_stormeurope(sector_bi, use_sector_bi_scaling)])
+        return ImpactFuncSet([get_sector_impf_stormeurope(sector_bi,country_iso3alpha, use_sector_bi_scaling)])
     if hazard.startswith('relative_crop_yield'):
         _, crop_type = agriculture.split_agriculture_hazard(hazard)
         return agriculture.get_impf_set(crop_type)

--- a/nccs/pipeline/direct/test/test_calc_yearset.py
+++ b/nccs/pipeline/direct/test/test_calc_yearset.py
@@ -19,7 +19,7 @@ class TestYearsets(unittest.TestCase):
 
     def test_yearset_with_poisson_process(self):
         """Yearsets have their basic functionality working"""
-        yimp = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, cap_exposure=1, seed=seed)
+        yimp = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, poisson=True, seed=seed)
         np.testing.assert_array_almost_equal(self.dummy_imp.imp_mat.shape, (6, 2))
         np.testing.assert_array_almost_equal(yimp.imp_mat.shape, (self.n_sim_years, 2))
         # The max yearset impact is greater than any individual event (with this seed)
@@ -27,7 +27,7 @@ class TestYearsets(unittest.TestCase):
 
     def test_yearset_with_non_poisson_process(self):
         """Our implementation of yearsets can handle sampling event sets where we always want exactly one event per year"""
-        yimp = yearset_from_imp(self.dummy_imp_yearly, n_sim_years = self.n_sim_years, cap_exposure=1, seed=seed)
+        yimp = yearset_from_imp(self.dummy_imp_yearly, n_sim_years = self.n_sim_years, poisson=False, seed=seed)
         np.testing.assert_array_almost_equal(self.dummy_imp_yearly.imp_mat.shape, (6, 2))
         np.testing.assert_array_almost_equal(yimp.imp_mat.shape, (self.n_sim_years, 2))
         # The max yearset impact is the same as the source impact (with this seed)
@@ -35,18 +35,20 @@ class TestYearsets(unittest.TestCase):
 
     def test_yearsets_sample_consistently_when_repeated(self):
         """If we generate yearsets a second time with the same seed we get the same sampling"""
-        yimp1 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, cap_exposure=1, seed=seed)
-        yimp2 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, cap_exposure=1, seed=seed)
+        yimp1 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, poisson=True, seed=seed)
+        yimp2 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, poisson=True, seed=seed)
         np.testing.assert_allclose(yimp1.at_event, yimp2.at_event)
 
     def test_yearsets_sample_differently_without_a_seed(self):
         """...but if we don't set the seed we get a different sampling"""
-        yimp1 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, cap_exposure=1, seed=seed)
-        yimp2 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years)
+        yimp1 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, poisson=True, seed=seed)
+        yimp2 = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, poisson=True)
         self.assertFalse(np.all(yimp1.at_event == yimp2.at_event))
     
     def test_yearsets_can_cap_exposures(self):
-        # TODO
+        yimp = yearset_from_imp(self.dummy_imp, n_sim_years = self.n_sim_years, poisson=True, cap_exposure=0.1, seed=seed)
+        self.assertTrue(np.max(yimp.at_event) == 0.2)  # Max impact of two exposures, each capped at 0.1
+        # TODO also test capping from an Exposures object
         pass
 
 


### PR DESCRIPTION
The implementation of yearsets had an error: event sets where each event corresponded to one year of simulated hazard (e.g. crop yield) were being sampled with a Poisson process, when actually they should have always been sampled
with one event per yearset year. This is fixed.

I've added it as a parameter to the method that specifies whether the underlying data should be considered a Poisson process or not. (Rather than trying to infer this, since it's usually the case if the event frequencies all add up to ~1.) 

At the same time a few other changes to yearsets:
- Yearset creation and combination allowed for individual impacts to be capped at the exposure level, either to a scalar value or according to an Exposures object (i..e. not more than 100% loss). This wasn't
properly implemented, and only changed the Impact object's impact matrix. This updates the calculation so that all the properties are updated. From a quick look through the results, it shouldn't really change anything.
- Change the default yearset impact cap from 1 to None. Seemed a bit dangerous to cap at 1 if we don't know the impacts have already been normalised. Doesn't affect any code because the value is always specified.
- Update tests
- Remove some old code tried to do this by overloading the CLIMADA code, but which didn't work, I think